### PR TITLE
Add map input to output to constrain tablet to a device. 

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -262,6 +262,8 @@ typedef struct {
 
 	char autostart[3][256];
 
+	char *tablet_output_name;
+
 	ConfigTagRule *tag_rules; // 动态数组
 	int tag_rules_count;	  // 数量
 
@@ -1983,6 +1985,11 @@ void parse_config_line(Config *config, const char *line) {
 
 	} else if (strncmp(key, "source", 6) == 0) {
 		parse_config_file(config, value);
+	} else if (strcmp(key, "tablet_output") == 0) {
+		if (config->tablet_output_name) {
+			free(config->tablet_output_name);
+		}
+		config->tablet_output_name = strdup(value);
 	} else {
 		fprintf(stderr, "Error: Unknown key: %s\n", key);
 	}
@@ -2268,6 +2275,11 @@ void free_config(void) {
 	if (config.cursor_theme) {
 		free(config.cursor_theme);
 		config.cursor_theme = NULL;
+	}
+
+	if (config.tablet_output_name) {
+		free(config.tablet_output_name);
+		config.tablet_output_name = NULL;
 	}
 
 	// 释放 circle_layout
@@ -2559,6 +2571,10 @@ void set_value_default() {
 	config.shadows_position_y = shadows_position_y;
 	config.focused_opacity = focused_opacity;
 	config.unfocused_opacity = unfocused_opacity;
+
+	/* tablet */
+	config.tablet_output_name = strdup("");
+	//
 	memcpy(config.shadowscolor, shadowscolor, sizeof(shadowscolor));
 
 	memcpy(config.animation_curve_move, animation_curve_move,

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -2572,9 +2572,9 @@ void set_value_default() {
 	config.focused_opacity = focused_opacity;
 	config.unfocused_opacity = unfocused_opacity;
 
-	/* tablet */
+	/* Tablet */
 	config.tablet_output_name = strdup("");
-	//
+
 	memcpy(config.shadowscolor, shadowscolor, sizeof(shadowscolor));
 
 	memcpy(config.animation_curve_move, animation_curve_move,

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -2573,7 +2573,7 @@ void set_value_default() {
 	config.unfocused_opacity = unfocused_opacity;
 
 	/* Tablet */
-	config.tablet_output_name = strdup("");
+	config.tablet_output_name = NULL;
 
 	memcpy(config.shadowscolor, shadowscolor, sizeof(shadowscolor));
 

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -1985,7 +1985,7 @@ void parse_config_line(Config *config, const char *line) {
 
 	} else if (strncmp(key, "source", 6) == 0) {
 		parse_config_file(config, value);
-	} else if (strcmp(key, "tablet_output") == 0) {
+	} else if (strcmp(key, "tablet_output_name") == 0) {
 		if (config->tablet_output_name) {
 			free(config->tablet_output_name);
 		}

--- a/src/ext-protocol/all.h
+++ b/src/ext-protocol/all.h
@@ -1,4 +1,5 @@
 #include "dwl-ipc.h"
 #include "ext-workspace.h"
 #include "foreign-toplevel.h"
+#include "tablet.h"
 #include "text-input.h"

--- a/src/ext-protocol/tablet.h
+++ b/src/ext-protocol/tablet.h
@@ -50,7 +50,7 @@ void createtablet(struct wlr_input_device *device) {
 														send_events_mode);
 			wlr_cursor_attach_input_device(cursor, device);
 			// Map tablet to specific monitor if configured
-			if (config.tablet_output_name[0] != '\0') {
+			if (config.tablet_output_name) {
 				Monitor *target_monitor = find_monitor_by_name(config.tablet_output_name);
 				if (target_monitor) {
 					wlr_log(WLR_INFO, "Mapping input to output for device: %s", config.tablet_output_name);

--- a/src/ext-protocol/tablet.h
+++ b/src/ext-protocol/tablet.h
@@ -56,6 +56,8 @@ void createtablet(struct wlr_input_device *device) {
 					wlr_log(WLR_INFO, "Mapping input to output for device: %s", config.tablet_output_name);
 					wlr_cursor_map_input_to_output(cursor, device, 
 																				 target_monitor->wlr_output);
+				} else {
+					wlr_log(WLR_WARN, "No monitor found with name: %s", config.tablet_output_name);
 				}
 			}
 		}

--- a/src/ext-protocol/tablet.h
+++ b/src/ext-protocol/tablet.h
@@ -1,0 +1,230 @@
+#include <wlr/types/wlr_tablet_pad.h>
+#include <wlr/types/wlr_tablet_tool.h>
+#include <wlr/types/wlr_tablet_v2.h>
+
+static const int tabletmaptosurface =
+	0; /* map tablet input to surface(1) or monitor(0) */
+
+static void createtablet(struct wlr_input_device *device);
+static void destroytablet(struct wl_listener *listener, void *data);
+static void destroytabletsurfacenotify(struct wl_listener *listener,
+									   void *data);
+static void destroytablettool(struct wl_listener *listener, void *data);
+
+static void tablettoolmotion(struct wlr_tablet_v2_tablet_tool *tool,
+							 bool change_x, bool change_y, double x, double y,
+							 double dx, double dy);
+static void tablettoolproximity(struct wl_listener *listener, void *data);
+static void tablettoolaxis(struct wl_listener *listener, void *data);
+static void tablettoolbutton(struct wl_listener *listener, void *data);
+static void tablettooltip(struct wl_listener *listener, void *data);
+static struct wlr_tablet_manager_v2 *tablet_mgr;
+static struct wlr_tablet_v2_tablet *tablet = NULL;
+static struct wlr_tablet_v2_tablet_tool *tablet_tool = NULL;
+static struct wlr_tablet_v2_tablet_pad *tablet_pad = NULL;
+static struct wlr_surface *tablet_curr_surface = NULL;
+static struct wl_listener destroy_tablet_surface_listener = {
+	.notify = destroytabletsurfacenotify};
+static struct wl_listener tablet_device_destroy = {.notify = destroytablet};
+static struct wl_listener tablet_tool_axis = {.notify = tablettoolaxis};
+static struct wl_listener tablet_tool_button = {.notify = tablettoolbutton};
+static struct wl_listener tablet_tool_destroy = {.notify = destroytablettool};
+static struct wl_listener tablet_tool_proximity = {.notify =
+													   tablettoolproximity};
+static struct wl_listener tablet_tool_tip = {.notify = tablettooltip};
+
+void createtablet(struct wlr_input_device *device) {
+	if (!tablet) {
+		struct libinput_device *device_handle = NULL;
+		if (!wlr_input_device_is_libinput(device) ||
+			!(device_handle = wlr_libinput_get_device_handle(device)))
+			return;
+
+		tablet = wlr_tablet_create(tablet_mgr, seat, device);
+		wl_signal_add(&tablet->wlr_device->events.destroy,
+					  &tablet_device_destroy);
+		if (libinput_device_config_send_events_get_modes(device_handle)) {
+			libinput_device_config_send_events_set_mode(device_handle,
+														send_events_mode);
+			wlr_cursor_attach_input_device(cursor, device);
+		}
+	} else if (device == tablet->wlr_device) {
+		wlr_log(WLR_ERROR, "createtablet: duplicate device");
+	} else {
+		wlr_log(WLR_ERROR, "createtablet: already have one tablet");
+	}
+}
+
+void destroytablet(struct wl_listener *listener, void *data) { tablet = NULL; }
+
+void destroytabletsurfacenotify(struct wl_listener *listener, void *data) {
+	if (tablet_curr_surface)
+		wl_list_remove(&destroy_tablet_surface_listener.link);
+	tablet_curr_surface = NULL;
+}
+
+void destroytablettool(struct wl_listener *listener, void *data) {
+	destroytabletsurfacenotify(NULL, NULL);
+	tablet_tool = NULL;
+}
+
+void tabletapplymap(double tablet_width, double tablet_height,
+		struct wlr_fbox box, double *x, double *y)
+{
+	if ((!box.x && !box.y && !box.width && !box.height)
+			|| !tablet_width || !tablet_height) {
+		return;
+	}
+
+	if (!box.width) {
+		box.width = tablet_width - box.x;
+	}
+	if (!box.height) {
+		box.height = tablet_height - box.y;
+	}
+
+	if (box.x + box.width <= tablet_width) {
+		const double max_x = 1;
+		double width_offset = max_x * box.x / tablet_width;
+		*x = (*x - width_offset) * tablet_width / box.width;
+	}
+	if (box.y + box.height <= tablet_height) {
+		const double max_y = 1;
+		double height_offset = max_y * box.y / tablet_height;
+		*y = (*y - height_offset) * tablet_height / box.height;
+	}
+}
+
+void tablettoolmotion(struct wlr_tablet_v2_tablet_tool *tool, bool change_x,
+					  bool change_y, double x, double y, double dx, double dy) {
+	struct wlr_surface *surface = NULL;
+	double sx, sy;
+
+	if (!change_x && !change_y)
+		return;
+
+	tabletapplymap(tablet->wlr_tablet->width_mm, tablet->wlr_tablet->height_mm,
+		(struct wlr_fbox){0}, &x, &y);
+
+	// TODO: apply constraints
+	switch (tablet_tool->wlr_tool->type) {
+	case WLR_TABLET_TOOL_TYPE_LENS:
+	case WLR_TABLET_TOOL_TYPE_MOUSE:
+		wlr_cursor_move(cursor, tablet->wlr_device, dx, dy);
+		break;
+	default:
+		wlr_cursor_warp_absolute(cursor, tablet->wlr_device, change_x ? x : NAN,
+								 change_y ? y : NAN);
+		break;
+	}
+
+	motionnotify(0, NULL, 0, 0, 0, 0);
+
+	xytonode(cursor->x, cursor->y, &surface, NULL, NULL, &sx, &sy);
+	if (surface && !wlr_surface_accepts_tablet_v2(surface, tablet))
+		surface = NULL;
+
+	if (surface != tablet_curr_surface) {
+		if (tablet_curr_surface) {
+			// TODO: wait until all buttons released before leaving
+			if (tablet_tool)
+				wlr_tablet_v2_tablet_tool_notify_proximity_out(tablet_tool);
+			if (tablet_pad)
+				wlr_tablet_v2_tablet_pad_notify_leave(tablet_pad,
+													  tablet_curr_surface);
+			wl_list_remove(&destroy_tablet_surface_listener.link);
+		}
+		if (surface) {
+			if (tablet_pad)
+				wlr_tablet_v2_tablet_pad_notify_enter(tablet_pad, tablet,
+													  surface);
+			if (tablet_tool)
+				wlr_tablet_v2_tablet_tool_notify_proximity_in(tablet_tool,
+															  tablet, surface);
+			wl_signal_add(&surface->events.destroy,
+						  &destroy_tablet_surface_listener);
+		}
+		tablet_curr_surface = surface;
+	}
+
+	if (surface)
+		wlr_tablet_v2_tablet_tool_notify_motion(tablet_tool, sx, sy);
+}
+
+void tablettoolproximity(struct wl_listener *listener, void *data) {
+	struct wlr_tablet_tool_proximity_event *event = data;
+	struct wlr_tablet_tool *tool = event->tool;
+
+	if (!tablet_tool) {
+		tablet_tool = wlr_tablet_tool_create(tablet_mgr, seat, tool);
+		wl_signal_add(&tablet_tool->wlr_tool->events.destroy,
+					  &tablet_tool_destroy);
+		wl_signal_add(&tablet_tool->events.set_cursor, &request_cursor);
+	}
+
+	switch (event->state) {
+	case WLR_TABLET_TOOL_PROXIMITY_OUT:
+		wlr_tablet_v2_tablet_tool_notify_proximity_out(tablet_tool);
+		destroytabletsurfacenotify(NULL, NULL);
+		break;
+	case WLR_TABLET_TOOL_PROXIMITY_IN:
+		tablettoolmotion(tablet_tool, true, true, event->x, event->y, 0, 0);
+		break;
+	}
+}
+
+void tablettoolaxis(struct wl_listener *listener, void *data) {
+	struct wlr_tablet_tool_axis_event *event = data;
+
+	tablettoolmotion(tablet_tool, event->updated_axes & WLR_TABLET_TOOL_AXIS_X,
+					 event->updated_axes & WLR_TABLET_TOOL_AXIS_Y, event->x,
+					 event->y, event->dx, event->dy);
+
+	if (event->updated_axes & WLR_TABLET_TOOL_AXIS_PRESSURE)
+		wlr_tablet_v2_tablet_tool_notify_pressure(tablet_tool, event->pressure);
+	if (event->updated_axes & WLR_TABLET_TOOL_AXIS_DISTANCE)
+		wlr_tablet_v2_tablet_tool_notify_distance(tablet_tool, event->distance);
+	if (event->updated_axes &
+		(WLR_TABLET_TOOL_AXIS_TILT_X | WLR_TABLET_TOOL_AXIS_TILT_Y)) {
+		printf("DEBUGGING: In axis event handling\n");
+		wlr_tablet_v2_tablet_tool_notify_tilt(tablet_tool, event->tilt_x,
+											  event->tilt_y);
+	}
+	if (event->updated_axes & WLR_TABLET_TOOL_AXIS_ROTATION)
+		wlr_tablet_v2_tablet_tool_notify_rotation(tablet_tool, event->rotation);
+	if (event->updated_axes & WLR_TABLET_TOOL_AXIS_SLIDER)
+		wlr_tablet_v2_tablet_tool_notify_slider(tablet_tool, event->slider);
+	if (event->updated_axes & WLR_TABLET_TOOL_AXIS_WHEEL)
+		wlr_tablet_v2_tablet_tool_notify_wheel(tablet_tool, event->wheel_delta,
+											   0);
+}
+
+void tablettoolbutton(struct wl_listener *listener, void *data) {
+	struct wlr_tablet_tool_button_event *event = data;
+	wlr_tablet_v2_tablet_tool_notify_button(
+		tablet_tool, event->button,
+		(enum zwp_tablet_pad_v2_button_state)event->state);
+}
+
+void tablettooltip(struct wl_listener *listener, void *data) {
+	struct wlr_tablet_tool_tip_event *event = data;
+
+	if (!tablet_curr_surface) {
+		struct wlr_pointer_button_event fakeptrbtnevent = {
+			.button = BTN_LEFT,
+			.state = event->state == WLR_TABLET_TOOL_TIP_UP
+						 ? WL_POINTER_BUTTON_STATE_RELEASED
+						 : WL_POINTER_BUTTON_STATE_PRESSED,
+			.time_msec = event->time_msec,
+		};
+		buttonpress(NULL, (void *)&fakeptrbtnevent);
+	}
+
+	if (event->state == WLR_TABLET_TOOL_TIP_UP) {
+		wlr_tablet_v2_tablet_tool_notify_up(tablet_tool);
+		return;
+	}
+
+	wlr_tablet_v2_tablet_tool_notify_down(tablet_tool);
+	wlr_tablet_tool_v2_start_implicit_grab(tablet_tool);
+}

--- a/src/ext-protocol/tablet.h
+++ b/src/ext-protocol/tablet.h
@@ -55,7 +55,10 @@ void createtablet(struct wlr_input_device *device) {
 	}
 }
 
-void destroytablet(struct wl_listener *listener, void *data) { tablet = NULL; }
+void destroytablet(struct wl_listener *listener, void *data) {
+	wl_list_remove(&listener->link);
+	tablet = NULL;
+}
 
 void destroytabletsurfacenotify(struct wl_listener *listener, void *data) {
 	if (tablet_curr_surface)
@@ -69,10 +72,9 @@ void destroytablettool(struct wl_listener *listener, void *data) {
 }
 
 void tabletapplymap(double tablet_width, double tablet_height,
-		struct wlr_fbox box, double *x, double *y)
-{
-	if ((!box.x && !box.y && !box.width && !box.height)
-			|| !tablet_width || !tablet_height) {
+					struct wlr_fbox box, double *x, double *y) {
+	if ((!box.x && !box.y && !box.width && !box.height) || !tablet_width ||
+		!tablet_height) {
 		return;
 	}
 
@@ -104,7 +106,7 @@ void tablettoolmotion(struct wlr_tablet_v2_tablet_tool *tool, bool change_x,
 		return;
 
 	tabletapplymap(tablet->wlr_tablet->width_mm, tablet->wlr_tablet->height_mm,
-		(struct wlr_fbox){0}, &x, &y);
+				   (struct wlr_fbox){0}, &x, &y);
 
 	// TODO: apply constraints
 	switch (tablet_tool->wlr_tool->type) {

--- a/src/mango.c
+++ b/src/mango.c
@@ -5616,6 +5616,17 @@ static void setgeometrynotify(struct wl_listener *listener, void *data) {
 }
 #endif
 
+static Monitor *find_monitor_by_name(const char *output_name) {
+	if (!output_name) return NULL;
+	Monitor *m;
+	wl_list_for_each(m, &mons, link) {
+			if (m->wlr_output && strcmp(m->wlr_output->name, output_name) == 0) {
+				return m;
+			}
+		}
+	return NULL;
+}
+
 int main(int argc, char *argv[]) {
 	char *startup_cmd = NULL;
 	int c;

--- a/src/mango.c
+++ b/src/mango.c
@@ -68,6 +68,9 @@
 #include <wlr/types/wlr_single_pixel_buffer_v1.h>
 #include <wlr/types/wlr_subcompositor.h>
 #include <wlr/types/wlr_switch.h>
+#include <wlr/types/wlr_tablet_pad.h>
+#include <wlr/types/wlr_tablet_tool.h>
+#include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/types/wlr_viewporter.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_virtual_pointer_v1.h>
@@ -3164,6 +3167,12 @@ void inputdevice(struct wl_listener *listener, void *data) {
 	case WLR_INPUT_DEVICE_KEYBOARD:
 		createkeyboard(wlr_keyboard_from_input_device(device));
 		break;
+	case WLR_INPUT_DEVICE_TABLET:
+		createtablet(device);
+		break;
+	case WLR_INPUT_DEVICE_TABLET_PAD:
+		tablet_pad = wlr_tablet_pad_create(tablet_mgr, seat, device);
+		break;
 	case WLR_INPUT_DEVICE_POINTER:
 		createpointer(wlr_pointer_from_input_device(device));
 		break;
@@ -4629,14 +4638,15 @@ void setup(void) {
 	dpy = wl_display_create();
 	event_loop = wl_display_get_event_loop(dpy);
 	pointer_manager = wlr_relative_pointer_manager_v1_create(dpy);
-	/* The backend is a wlroots feature which abstracts the underlying input
-	 * and output hardware. The autocreate option will choose the most
-	 * suitable backend based on the current environment, such as opening an
-	 * X11 window if an X11 server is running. The NULL argument here
-	 * optionally allows you to pass in a custom renderer if wlr_renderer
-	 * doesn't meet your needs. The backend uses the renderer, for example,
-	 * to fall back to software cursors if the backend does not support
-	 * hardware cursors (some older GPUs don't). */
+	tablet_mgr = wlr_tablet_v2_create(dpy);
+	/* The backend is a wlroots feature which abstracts the underlying input and
+	 * output hardware. The autocreate option will choose the most suitable
+	 * backend based on the current environment, such as opening an X11 window
+	 * if an X11 server is running. The NULL argument here optionally allows you
+	 * to pass in a custom renderer if wlr_renderer doesn't meet your needs. The
+	 * backend uses the renderer, for example, to fall back to software cursors
+	 * if the backend does not support hardware cursors (some older GPUs
+	 * don't). */
 	if (!(backend = wlr_backend_autocreate(event_loop, &session)))
 		die("couldn't create backend");
 
@@ -4803,6 +4813,11 @@ void setup(void) {
 	wl_signal_add(&cursor->events.button, &cursor_button);
 	wl_signal_add(&cursor->events.axis, &cursor_axis);
 	wl_signal_add(&cursor->events.frame, &cursor_frame);
+	wl_signal_add(&cursor->events.tablet_tool_proximity,
+				  &tablet_tool_proximity);
+	wl_signal_add(&cursor->events.tablet_tool_axis, &tablet_tool_axis);
+	wl_signal_add(&cursor->events.tablet_tool_button, &tablet_tool_button);
+	wl_signal_add(&cursor->events.tablet_tool_tip, &tablet_tool_tip);
 
 	// 这两句代码会造成obs窗口里的鼠标光标消失,不知道注释有什么影响
 	cursor_shape_mgr = wlr_cursor_shape_manager_v1_create(dpy, 1);


### PR DESCRIPTION
Tablets will use all monitors by default, making the usable surface very small. This constrains the tablet to a single monitor, similar to [input `<identifier>` map_to_output `<identifier>`](https://man.archlinux.org/man/sway-input.5#MAPPING_CONFIGURATION) in sway. Might make sense to for the similar behavior if they have multiple tablets on the same machine to map them directly.

- Add map input to output to constrain tablet to a device. 
- Config option tablet_output_name for the monitor to output to 

I can make any changes to variable names or structure. 

Example config: 
```
tablet_output_name=DP-3
```