### PR TITLE
limit scanf string read

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -1812,7 +1812,7 @@ void parse_option(Config *config, char *key, char *value) {
 			arg_value[256] = "0\0", arg_value2[256] = "0\0",
 			arg_value3[256] = "0\0", arg_value4[256] = "0\0",
 			arg_value5[256] = "0\0";
-		if (sscanf(value, "%256[^,],%256[^,],%256[^,],%256[^,],%256[^,],%256[^,],%256[^,],%256[^\n]",
+		if (sscanf(value, "%255[^,],%255[^,],%255[^,],%255[^,],%255[^,],%255[^,],%255[^,],%255[^\n]",
 				   mod_str, keysym_str, func_name, arg_value, arg_value2,
 				   arg_value3, arg_value4, arg_value5) < 3) {
 			fprintf(stderr, "Error: Invalid bind format: %s\n", value);

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -1812,7 +1812,7 @@ void parse_option(Config *config, char *key, char *value) {
 			arg_value[256] = "0\0", arg_value2[256] = "0\0",
 			arg_value3[256] = "0\0", arg_value4[256] = "0\0",
 			arg_value5[256] = "0\0";
-		if (sscanf(value, "%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^,],%[^\n]",
+		if (sscanf(value, "%256[^,],%256[^,],%256[^,],%256[^,],%256[^,],%256[^,],%256[^,],%256[^\n]",
 				   mod_str, keysym_str, func_name, arg_value, arg_value2,
 				   arg_value3, arg_value4, arg_value5) < 3) {
 			fprintf(stderr, "Error: Invalid bind format: %s\n", value);


### PR DESCRIPTION
This should fix the buffer overflow issue the the bind command by limiting the amount
of characters to read for each buffer.

A more robust solution might be to heap allocated the require amount of bytes dynamically in `parse_config.h`