### PR TITLE
Consolidate duplicate lines, return bool instead of uint32_t

### DIFF
--- a/src/mango.c
+++ b/src/mango.c
@@ -978,11 +978,7 @@ void clear_fullscreen_and_maximized_state(Monitor *m) {
 /*清除全屏标志,还原全屏时清0的border*/
 void clear_fullscreen_flag(Client *c) {
 
-	if ((c->mon->pertag->ltidxs[get_tags_first_tag_num(c->tags)]->id ==
-			 SCROLLER ||
-		 c->mon->pertag->ltidxs[get_tags_first_tag_num(c->tags)]->id ==
-			 VERTICAL_SCROLLER) &&
-		!c->isfloating) {
+	if (is_scroller_layout(c->mon) && !c->isfloating) {
 		return;
 	}
 
@@ -5257,11 +5253,7 @@ bool want_restore_fullscreen(Client *target_client) {
 	Client *c = NULL;
 	wl_list_for_each(c, &clients, link) {
 		if (c && c != target_client && c->tags == target_client->tags &&
-			c == selmon->sel &&
-			c->mon->pertag->ltidxs[get_tags_first_tag_num(c->tags)]->id !=
-				SCROLLER &&
-			c->mon->pertag->ltidxs[get_tags_first_tag_num(c->tags)]->id !=
-				VERTICAL_SCROLLER) {
+			c == selmon->sel && !is_scroller_layout(c->mon)) {
 			return false;
 		}
 	}


### PR DESCRIPTION
Consolidates some duplicate code by moving it out of their conditions and changes `want_restore_fullscreen` to return a `bool` instead of `uint32_t`. Also passes `blur_optimized` directly as C implicitly converts it to a `bool`. I compiled and tested this briefly but haven't tested everything yet.