### PR TITLE
feat: allow fullscreen windows to have opacity

### DIFF
--- a/config.conf
+++ b/config.conf
@@ -24,6 +24,7 @@ border_radius=6
 no_radius_when_single=0
 focused_opacity=1.0
 unfocused_opacity=1.0
+allow_fullscreen_opacity=0
 
 # Animation Configuration(support type:zoom,slide)
 # tag_animation_direction: 1-horizontal,0-vertical

--- a/src/animation/client.h
+++ b/src/animation/client.h
@@ -1105,7 +1105,8 @@ bool client_apply_focus_opacity(Client *c) {
 	float *border_color = get_border_color(c);
 	if (c->isfullscreen) {
 		c->opacity_animation.running = false;
-		client_set_opacity(c, 1);
+		client_set_opacity(
+			c, config.allow_fullscreen_opacity ? opacity : 1.0f);
 	} else if (c->animation.running && c->animation.action == OPEN) {
 		c->opacity_animation.running = false;
 		struct timespec now;

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -349,6 +349,8 @@ typedef struct {
 	int32_t allow_shortcuts_inhibit;
 	int32_t allow_lock_transparent;
 
+	int32_t allow_fullscreen_opacity;
+
 	struct xkb_rule_names xkb_rules;
 
 	char keymode[28];
@@ -1281,6 +1283,8 @@ void parse_option(Config *config, char *key, char *value) {
 		config->allow_shortcuts_inhibit = atoi(value);
 	} else if (strcmp(key, "allow_lock_transparent") == 0) {
 		config->allow_lock_transparent = atoi(value);
+	} else if (strcmp(key, "allow_fullscreen_opacity") == 0) {
+		config->allow_fullscreen_opacity = atoi(value);
 	} else if (strcmp(key, "no_border_when_single") == 0) {
 		config->no_border_when_single = atoi(value);
 	} else if (strcmp(key, "no_radius_when_single") == 0) {
@@ -2747,6 +2751,7 @@ void override_config(void) {
 	allow_tearing = CLAMP_INT(config.allow_tearing, 0, 2);
 	allow_shortcuts_inhibit = CLAMP_INT(config.allow_shortcuts_inhibit, 0, 1);
 	allow_lock_transparent = CLAMP_INT(config.allow_lock_transparent, 0, 1);
+	allow_fullscreen_opacity = CLAMP_INT(config.allow_fullscreen_opacity, 0, 1);
 	axis_bind_apply_timeout =
 		CLAMP_INT(config.axis_bind_apply_timeout, 0, 1000);
 	focus_on_activate = CLAMP_INT(config.focus_on_activate, 0, 1);
@@ -2932,6 +2937,7 @@ void set_value_default() {
 	config.allow_tearing = allow_tearing;
 	config.allow_shortcuts_inhibit = allow_shortcuts_inhibit;
 	config.allow_lock_transparent = allow_lock_transparent;
+	config.allow_fullscreen_opacity = allow_fullscreen_opacity;
 	config.no_border_when_single = no_border_when_single;
 	config.no_radius_when_single = no_radius_when_single;
 	config.snap_distance = snap_distance;

--- a/src/config/preset.h
+++ b/src/config/preset.h
@@ -106,6 +106,9 @@ int32_t xwayland_persistence = 1; /* xwayland persistence */
 int32_t syncobj_enable = 0;
 int32_t adaptive_sync = 0;
 int32_t allow_lock_transparent = 0;
+
+int32_t allow_fullscreen_opacity = 0;
+
 double drag_refresh_interval = 16.0;
 int32_t allow_tearing = TEARING_DISABLED;
 int32_t allow_shortcuts_inhibit = SHORTCUTS_INHIBIT_ENABLE;

--- a/src/mango.c
+++ b/src/mango.c
@@ -936,11 +936,11 @@ static struct wl_listener xwayland_ready = {.notify = xwaylandready};
 static struct wlr_xwayland *xwayland;
 #endif
 
+#include "config/parse_config.h"
 #include "animation/client.h"
 #include "animation/common.h"
 #include "animation/layer.h"
 #include "animation/tag.h"
-#include "config/parse_config.h"
 #include "dispatch/bind_define.h"
 #include "ext-protocol/all.h"
 #include "fetch/fetch.h"


### PR DESCRIPTION
Adds `allow_fullscreen_opacity` config option. When enabled, fullscreen windows 
respect `[un]focused_opacity` settings instead of always being fully opaque.

This doesn't hurt to have as compositor-specific behavior while transparent 
fullscreen remains unsettled in the protocol:
https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/116