### PR TITLE
Support width/height as fractions in window rules. Closes #552

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -80,8 +80,8 @@ typedef struct {
 	const char *monitor;
 	int32_t offsetx;
 	int32_t offsety;
-	int32_t width;
-	int32_t height;
+	float width;
+	float height;
 	int32_t nofocus;
 	int32_t nofadein;
 	int32_t nofadeout;
@@ -1805,9 +1805,9 @@ void parse_option(Config *config, char *key, char *value) {
 				} else if (strcmp(key, "no_force_center") == 0) {
 					rule->no_force_center = atoi(val);
 				} else if (strcmp(key, "width") == 0) {
-					rule->width = atoi(val);
+					rule->width = atof(val);
 				} else if (strcmp(key, "height") == 0) {
-					rule->height = atoi(val);
+					rule->height = atof(val);
 				} else if (strcmp(key, "isnoborder") == 0) {
 					rule->isnoborder = atoi(val);
 				} else if (strcmp(key, "isnoshadow") == 0) {

--- a/src/mango.c
+++ b/src/mango.c
@@ -1360,10 +1360,14 @@ void applyrules(Client *c) {
 
 		// set geometry of floating client
 
-		if (r->width > 0)
+		if (r->width > 1)
 			c->float_geom.width = r->width;
-		if (r->height > 0)
+		else if (r->width > 0 && r->width <= 1)
+			c->float_geom.width = round(mon->m.width * r->width);
+		if (r->height > 1)
 			c->float_geom.height = r->height;
+		else if (r->height > 0 && r->height <= 1)
+			c->float_geom.height = round(mon->m.height * r->height);
 
 		if (r->width > 0 || r->height > 0) {
 			c->iscustomsize = 1;


### PR DESCRIPTION
# What does this PR add?
This PR adds support for specifying windows' width and height as a fraction of the screen real estate. See #552 as to why this is useful

# Changes

- in window rules, `width` and `height` can now be specified _also_ as a float between 0 and 1. If they are, then the window's width and height are computed based on the monitor screen estate

if `width`/`height` are specified with a number above 1, previous behaviour applies.

## Possible improvements
- this should be documented in the wiki, I can open a PR there if you wish