### PR TITLE
feat: atstartup rule that only applies within 60s of startup

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -78,6 +78,7 @@ typedef struct {
 	int32_t ignore_maximize;
 	int32_t ignore_minimize;
 	int32_t isnosizehint;
+	int32_t atstartup;
 	int32_t indleinhibit_when_focus;
 	char *monitor;
 	int32_t offsetx;
@@ -2039,6 +2040,7 @@ bool parse_option(Config *config, char *key, char *value) {
 		rule->isnosizehint = -1;
 		rule->indleinhibit_when_focus = -1;
 		rule->isterm = -1;
+		rule->atstartup = -1;
 		rule->allow_csd = -1;
 		rule->force_maximize = -1;
 		rule->force_tiled_state = -1;
@@ -2170,6 +2172,8 @@ bool parse_option(Config *config, char *key, char *value) {
 					rule->isfullscreen = atoi(val);
 				} else if (strcmp(key, "isfakefullscreen") == 0) {
 					rule->isfakefullscreen = atoi(val);
+				} else if (strcmp(key, "atstartup") == 0) {
+					rule->atstartup = atoi(val);
 				} else if (strcmp(key, "globalkeybinding") == 0) {
 					char mod_str[256], keysym_str[256];
 					sscanf(val, "%255[^-]-%255[a-zA-Z]", mod_str, keysym_str);

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -78,6 +78,7 @@ typedef struct {
 	int32_t ignore_maximize;
 	int32_t ignore_minimize;
 	int32_t isnosizehint;
+	int32_t atstartup;
 	int32_t idleinhibit_when_focus;
 	char *monitor;
 	int32_t offsetx;
@@ -2284,6 +2285,7 @@ bool parse_option(Config *config, char *key, char *value) {
 		rule->isnosizehint = -1;
 		rule->idleinhibit_when_focus = -1;
 		rule->isterm = -1;
+		rule->atstartup = -1;
 		rule->allow_csd = -1;
 		rule->force_fakemaximize = -1;
 		rule->force_tiled_state = -1;
@@ -2415,6 +2417,8 @@ bool parse_option(Config *config, char *key, char *value) {
 					rule->isfullscreen = atoi(val);
 				} else if (strcmp(key, "isfakefullscreen") == 0) {
 					rule->isfakefullscreen = atoi(val);
+				} else if (strcmp(key, "atstartup") == 0) {
+					rule->atstartup = atoi(val);
 				} else if (strcmp(key, "globalkeybinding") == 0) {
 					char mod_str[256], keysym_str[256];
 					sscanf(val, "%255[^-]-%255[a-zA-Z]", mod_str, keysym_str);

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -88,6 +88,7 @@ typedef struct {
 	int32_t ignore_maximize;
 	int32_t ignore_minimize;
 	int32_t isnosizehint;
+	int32_t atstartup;
 	int32_t idleinhibit_when_focus;
 	int32_t vrr_only_fullscreen;
 	int32_t force_render;
@@ -2708,6 +2709,7 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 		rule->force_render = -1;
 		rule->activation_bypass = -1;
 		rule->isterm = -1;
+		rule->atstartup = -1;
 		rule->allow_csd = -1;
 		rule->force_fakemaximize = -1;
 		rule->force_tiled_state = -1;
@@ -2847,6 +2849,8 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 					rule->isfullscreen = atoi(val);
 				} else if (strcmp(key, "isfakefullscreen") == 0) {
 					rule->isfakefullscreen = atoi(val);
+				} else if (strcmp(key, "atstartup") == 0) {
+					rule->atstartup = atoi(val);
 				} else if (strcmp(key, "globalkeybinding") == 0) {
 					char mod_str[256], keysym_str[256];
 					sscanf(val, "%255[^-]-%255[a-zA-Z]", mod_str, keysym_str);

--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -1278,10 +1278,14 @@ void applyrules(Client *c) {
 		if (!is_window_rule_matches(r, appid, title))
 			continue;
 
+		// rule is after 60s of startup, do not apply
+		if (r->atstartup == 1 && get_now_in_ms() - startup_time > 60 * 1000)
+			continue;
+
 		// set general properties
 		apply_rule_properties(c, r);
 
-		// // set tags
+		// set tags
 		if (r->tags > 0) {
 			newtags |= r->tags;
 		} else if (parent) {

--- a/src/mango.c
+++ b/src/mango.c
@@ -813,6 +813,7 @@ static void pre_caculate_before_arrange(Monitor *m, bool want_animation,
 /* variables */
 static const char broken[] = "broken";
 static pid_t child_pid = -1;
+static uint32_t startup_time;
 static int32_t locked;
 static uint32_t locked_mods = 0;
 static void *exclusive_focus;
@@ -1432,10 +1433,14 @@ void applyrules(Client *c) {
 		if (!is_window_rule_matches(r, appid, title))
 			continue;
 
+		// rule is after 60s of startup, do not apply
+		if (r->atstartup && get_now_in_ms() - startup_time > 60 * 1000)
+			continue;
+
 		// set general properties
 		apply_rule_properties(c, r);
 
-		// // set tags
+		// set tags
 		if (r->tags > 0) {
 			newtags |= r->tags;
 		} else if (parent) {
@@ -5757,6 +5762,9 @@ void setup(void) {
 	}
 	sync_keymap = wl_event_loop_add_timer(wl_display_get_event_loop(dpy),
 										  synckeymap, NULL);
+
+	// store the startup time for at-startup rules to check against
+	startup_time = get_now_in_ms();
 #endif
 }
 

--- a/src/mango.c
+++ b/src/mango.c
@@ -926,6 +926,7 @@ static void begin_jump_mode(Monitor *m);
 /* variables */
 static const char broken[] = "broken";
 static pid_t child_pid = -1;
+static uint32_t startup_time;
 static int32_t locked;
 static uint32_t locked_mods = 0;
 static void *exclusive_focus;
@@ -1664,10 +1665,14 @@ void applyrules(Client *c) {
 		if (!is_window_rule_matches(r, appid, title))
 			continue;
 
+		// rule is after 60s of startup, do not apply
+		if (r->atstartup == 1 && get_now_in_ms() - startup_time > 60 * 1000)
+			continue;
+
 		// set general properties
 		apply_rule_properties(c, r);
 
-		// // set tags
+		// set tags
 		if (r->tags > 0) {
 			newtags |= r->tags;
 		} else if (parent) {
@@ -6220,6 +6225,9 @@ void setup(void) {
 	}
 	sync_keymap = wl_event_loop_add_timer(wl_display_get_event_loop(dpy),
 										  synckeymap, NULL);
+
+	// store the startup time for at-startup rules to check against
+	startup_time = get_now_in_ms();
 #endif
 }
 

--- a/src/mango.c
+++ b/src/mango.c
@@ -1101,6 +1101,7 @@ Monitor *get_monitor_nearest_to(int32_t lx, int32_t ly);
 /* variables */
 static const char broken[] = "broken";
 static pid_t child_pid = -1;
+static uint32_t startup_time;
 static int32_t locked;
 static uint32_t locked_mods = 0;
 static void *exclusive_focus;
@@ -1959,6 +1960,9 @@ void setup(void) {
 	}
 	sync_keymap = wl_event_loop_add_timer(wl_display_get_event_loop(dpy),
 										  synckeymap, NULL);
+
+	// store the startup time for at-startup rules to check against
+	startup_time = get_now_in_ms();
 #endif
 }
 


### PR DESCRIPTION
Add atstartup rule that only applies within the first 60s of mango starting, the motivation is for opening applications on certain tags on boot, outlined in #649.

I chose to do the startup rule since it seems to be the easiest one to implement; I don't see a simple way of implementing the generic one-shot rule.

Ideally, I would update the docs too, but I can't find a public repo for those. :sweat_smile: 