### PR TITLE
feat: add tag_orientation switch, refactor focusdir dispatcher to properly …

### DIFF
--- a/config.conf
+++ b/config.conf
@@ -82,6 +82,7 @@ sloppyfocus=1
 warpcursor=1
 focus_cross_monitor=0
 focus_cross_tag=0
+tag_orientation=0
 enable_floating_snap=0
 snap_distance=30
 cursor_size=24

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -217,6 +217,7 @@ typedef struct {
 	int32_t exchange_cross_monitor;
 	int32_t scratchpad_cross_monitor;
 	int32_t focus_cross_tag;
+	int32_t tag_orientation;
 	int32_t view_current_to_back;
 	int32_t no_border_when_single;
 	int32_t no_radius_when_single;
@@ -1351,6 +1352,8 @@ bool parse_option(Config *config, char *key, char *value) {
 		config->scratchpad_cross_monitor = atoi(value);
 	} else if (strcmp(key, "focus_cross_tag") == 0) {
 		config->focus_cross_tag = atoi(value);
+	} else if (strcmp(key, "tag_orientation") == 0) {
+		config->tag_orientation = atoi(value);
 	} else if (strcmp(key, "view_current_to_back") == 0) {
 		config->view_current_to_back = atoi(value);
 	} else if (strcmp(key, "blur") == 0) {
@@ -3146,6 +3149,7 @@ void override_config(void) {
 	exchange_cross_monitor = CLAMP_INT(config.exchange_cross_monitor, 0, 1);
 	scratchpad_cross_monitor = CLAMP_INT(config.scratchpad_cross_monitor, 0, 1);
 	focus_cross_tag = CLAMP_INT(config.focus_cross_tag, 0, 1);
+	tag_orientation = CLAMP_INT(config.tag_orientation, 0, 1);
 	view_current_to_back = CLAMP_INT(config.view_current_to_back, 0, 1);
 	enable_floating_snap = CLAMP_INT(config.enable_floating_snap, 0, 1);
 	snap_distance = CLAMP_INT(config.snap_distance, 0, 99999);
@@ -3313,6 +3317,7 @@ void set_value_default() {
 	config.exchange_cross_monitor = exchange_cross_monitor;
 	config.scratchpad_cross_monitor = scratchpad_cross_monitor;
 	config.focus_cross_tag = focus_cross_tag;
+	config.tag_orientation = tag_orientation;
 	config.axis_scroll_factor = axis_scroll_factor;
 	config.view_current_to_back = view_current_to_back;
 	config.single_scratchpad = single_scratchpad;

--- a/src/config/preset.h
+++ b/src/config/preset.h
@@ -69,6 +69,7 @@ int32_t scroller_prefer_center = 0;
 int32_t scroller_prefer_overspread = 1;
 int32_t focus_cross_monitor = 0;
 int32_t focus_cross_tag = 0;
+int32_t tag_orientation = 0;
 int32_t exchange_cross_monitor = 0;
 int32_t scratchpad_cross_monitor = 0;
 int32_t view_current_to_back = 0;

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -142,13 +142,24 @@ int32_t focusdir(const Arg *arg) {
 			warp_cursor(c);
 	} else {
 		if (config.focus_cross_tag) {
-			if (arg->i == LEFT || arg->i == UP)
-				viewtoleft_have_client(&(Arg){0});
-			if (arg->i == RIGHT || arg->i == DOWN)
-				viewtoright_have_client(&(Arg){0});
-		} else if (config.focus_cross_monitor) {
-			focusmon(arg);
-		}
+            if (config.tag_orientation) {
+                if (arg->i == DOWN) {
+                    viewtoright_have_client(&(Arg){0});
+                } else if (arg->i == UP) {
+                    viewtoleft_have_client(&(Arg){0});
+                } else if (config.focus_cross_monitor) {
+                    focusmon(arg);
+                }
+            } else {
+                if (arg->i == RIGHT) {
+                    viewtoright_have_client(&(Arg){0});
+                } else if (arg->i == LEFT) {
+                    viewtoleft_have_client(&(Arg){0});
+                } else if (config.focus_cross_monitor) {
+                    focusmon(arg);
+                }
+            }
+        }
 	}
 	return 0;
 }


### PR DESCRIPTION
…support it with focus_cross_tag and focus_cross_monitor


Added switch `tag_orientation` to configuration, with default being 0 and meaning horizontal tag switching, 1 meaning vertical. This is primarily to make it possible to use cross monitor and cross tag focus for people like me, with horizontal layout of monitors and vertical mental image of tags.

The `focusdir` dispatcher is refactored to take into account all three aforementioned switches and produce intuitive behavior for all users.


All tested.