### PR TITLE
NixOS: wl-only branch bump wlroots_0_19 to wlroots_0_20

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -16,7 +16,7 @@
   meson,
   ninja,
   scenefx,
-  wlroots_0_19,
+  wlroots_0_20,
   libGL,
   enableXWayland ? true,
   debug ? false,
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
       pixman
       wayland
       wayland-protocols
-      wlroots_0_19
+      wlroots_0_20
       scenefx
       libGL
     ]


### PR DESCRIPTION
Good afternoon, all,
I just did a simple fix to the wl-only branch to bump the wlroots library from 0.19->0.20 so it builds again.
Edit: I tested to make sure it would build on my system first, and it builds.