### PR TITLE
feat: add gtk and kde appmenu protocols

### DIFF
--- a/protocols/gtk-shell.xml
+++ b/protocols/gtk-shell.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="gtk">
+  <copyright><![CDATA[
+    SPDX-FileCopyrightText: GTK contributors
+
+    SPDX-License-Identifier: LGPL-2.1-or-later
+  ]]></copyright>
+
+  <!--
+    Trimmed subset of GTK's gtk-shell.xml, vendored from:
+      https://gitlab.gnome.org/GNOME/gtk
+      gdk/wayland/protocol/gtk-shell.xml
+    Upstream declares both interfaces at version 7. This copy is
+    pruned to version 1, retaining only the requests and events that
+    mango handles. The motivating use is set_dbus_properties, which
+    publishes the per-surface DBus app-menu metadata that mango
+    re-broadcasts to external panels (mangowm/mango#832).
+
+    Removed relative to upstream (none of these affect menu publication):
+      gtk_shell1: notify_launch (since 3)
+      gtk_surface1: configure_edges, edge_constraint enum (since 2),
+                    request_focus (since 3), release (since 4),
+                    titlebar_gesture, gesture/error enums (since 5),
+                    set_a11y_properties (since 7),
+                    tiled_top/right/bottom/left state values (since 2)
+
+    Kept-but-unimplemented vtable slots (no-ops in the compositor):
+      gtk_shell1.set_startup_id, gtk_shell1.system_bell,
+      gtk_surface1.set_modal, gtk_surface1.unset_modal,
+      gtk_surface1.present
+  -->
+
+  <interface name="gtk_shell1" version="1">
+    <description summary="gtk specific extensions">
+      gtk_shell is a protocol extension providing additional features for
+      clients implementing it.
+    </description>
+
+    <enum name="capability">
+      <entry name="global_app_menu" value="1"/>
+      <entry name="global_menu_bar" value="2"/>
+      <entry name="desktop_icons" value="3"/>
+    </enum>
+
+    <event name="capabilities">
+      <arg name="capabilities" type="uint"/>
+    </event>
+
+    <request name="get_gtk_surface">
+      <arg name="gtk_surface" type="new_id" interface="gtk_surface1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+
+    <request name="set_startup_id">
+      <arg name="startup_id" type="string" allow-null="true"/>
+    </request>
+
+    <request name="system_bell">
+      <arg name="surface" type="object" interface="gtk_surface1" allow-null="true"/>
+    </request>
+  </interface>
+
+  <interface name="gtk_surface1" version="1">
+    <request name="set_dbus_properties">
+      <arg name="application_id" type="string" allow-null="true"/>
+      <arg name="app_menu_path" type="string" allow-null="true"/>
+      <arg name="menubar_path" type="string" allow-null="true"/>
+      <arg name="window_object_path" type="string" allow-null="true"/>
+      <arg name="application_object_path" type="string" allow-null="true"/>
+      <arg name="unique_bus_name" type="string" allow-null="true"/>
+    </request>
+
+    <request name="set_modal"/>
+    <request name="unset_modal"/>
+
+    <request name="present">
+      <arg name="time" type="uint"/>
+    </request>
+
+    <enum name="state">
+      <entry name="tiled" value="1"/>
+    </enum>
+
+    <event name="configure">
+      <arg name="states" type="array"/>
+    </event>
+  </interface>
+
+</protocol>

--- a/protocols/kde-appmenu.xml
+++ b/protocols/kde-appmenu.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="appmenu">
+  <copyright><![CDATA[
+    SPDX-FileCopyrightText: 2017 David Edmundson <davidedmundson@kde.org>
+
+    SPDX-License-Identifier: MIT
+  ]]></copyright>
+
+  <!--
+    Vendored verbatim from plasma-wayland-protocols:
+      https://invent.kde.org/libraries/plasma-wayland-protocols
+      src/protocols/appmenu.xml
+    Used by mango to support global application menus on Wayland
+    (mangowm/mango#832). The compositor stores the per-surface DBus
+    address published by clients and re-broadcasts it to external
+    panels via the dwl-ipc-unstable-v2 protocol.
+  -->
+
+  <interface name="org_kde_kwin_appmenu_manager" version="2">
+      <description summary="appmenu dbus address interface">
+          This interface allows a client to link a window (or wl_surface) to an com.canonical.dbusmenu
+          interface registered on DBus.
+      </description>
+      <request name="create">
+          <arg name="id" type="new_id" interface="org_kde_kwin_appmenu"/>
+          <arg name="surface" type="object" interface="wl_surface"/>
+      </request>
+      <!-- version 2 additions-->
+      <request name="release" type="destructor" since="2">
+          <description summary="destroy the org_kde_kwin_appmenu_manager object" />
+      </request>
+  </interface>
+  <interface name="org_kde_kwin_appmenu" version="2">
+      <description summary="appmenu dbus address interface">
+          The DBus service name and object path where the appmenu interface is present
+          The object should be registered on the session bus before sending this request.
+          If not applicable, clients should remove this object.
+      </description>
+      <request name="set_address">
+          <description summary="initialise or update the location of the AppMenu interface">
+              Set or update the service name and object path.
+              Strings should be formatted in Latin-1 matching the relevant DBus specifications.
+          </description>
+          <arg name="service_name" type="string" />
+          <arg name="object_path" type="string" />
+      </request>
+      <request name="release" type="destructor">
+        <description summary="release the appmenu object"/>
+      </request>
+  </interface>
+</protocol>

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -24,6 +24,8 @@ wayland_xmls = [
 	'dwl-ipc-unstable-v2.xml',
 	'wlr-layer-shell-unstable-v1.xml',
 	'wlr-output-power-management-unstable-v1.xml',
+	'kde-appmenu.xml',
+	'gtk-shell.xml',
 ]
 wayland_sources = [
 	wayland_scanner_code.process(wayland_xmls),


### PR DESCRIPTION
First step toward [issue #832 (global application menus on Wayland)](https://github.com/mangowm/mango/issues/832). This PR adds two Wayland protocol XMLs into `protocols/` and wires them into the meson build. My plan is to raise follow up PRs to build on top of this :
  1. **(this PR)** Add the two protocol XMLs.
  2. Implement `org_kde_kwin_appmenu` server-side: store per-`Client` state, register the global.
  3. Implement the trimmed `gtk_shell1` server-side. Same shape.
  4. Bump `dwl-ipc-unstable-v2` to interface version 3, add a single new `appmenu` event carrying both protocols' fields, expose them via `mmsg -M`, with backwards-compatible versions so old panels keep working.

## Files in this PR
  - **`protocols/kde-appmenu.xml`** (new) — verbatim copy from
  [plasma-wayland-protocols](https://invent.kde.org/libraries/plasma-wayland-protocols/-/blob/master/src/protocols/appmenu.xml), MIT licensed. Provenance + SPDX header inline.
  - **`protocols/gtk-shell.xml`** (new) — *trimmed* subset of GTK's [gtk-shell.xml](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gdk/wayland/protocol/gtk-shell.xml),
  LGPL-2.1-or-later. Provenance + trim notes inline.
  - **`protocols/meson.build`** — appends the two filenames to `wayland_xmls`.

## Why the GTK XML is trimmed

Upstream `gtk-shell.xml` declares both `gtk_shell1` and `gtk_surface1` at version 7. The vast majority of that surface area is unrelated to menus — tiled-state CSD hints (v2), focus-stealing bypass (v3), titlebar gestures (v5), accessibility paths (v7), startup notification (v3), etc. Each would require a stub handler in the compositor.

To keep the implementation surface area minimal, this XML declares both interfaces at **version 1**, retaining only what's needed for menu publication:

  - `gtk_shell1`: `get_gtk_surface`, `capabilities` event
  - `gtk_surface1`: `set_dbus_properties`

plus the other v1 requests that **must remain** for opcode alignment with the upstream wire format (`set_startup_id`, `system_bell`, `set_modal`, `unset_modal`, `present`). 


## Verification
  - `meson setup build && meson compile -C build` succeeds — wayland-scanner generates `kde-appmenu-protocol.{c,h}` and `gtk-shell-protocol.{c,h}` with no warnings.
  - Both XMLs are well-formed (`xmllint --noout`).
  - Smoke-tested that mango still launches and `mmsg -g` output is unchanged from `main`.