### PR TITLE
feat: add OpenBSD support

### DIFF
--- a/src/action/monitor.h
+++ b/src/action/monitor.h
@@ -13,6 +13,11 @@ bool mango_scene_output_commit(struct wlr_scene_output *scene_output,
 	if (!wlr_scene_output_build_state(scene_output, state, NULL))
 		return false;
 
+	if (m->need_init_hdr) {
+		output_state_setup_hdr(m, false, state);
+		m->need_init_hdr = false;
+	}
+
 	if (frame_allow_tearing) {
 		state->tearing_page_flip = true;
 	} else {

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -4108,14 +4108,11 @@ void reapply_monitor_rules(void) {
 		}
 
 		if (m->hdr_enable) {
-			output_state_setup_hdr(m, false, &m->pending);
+			m->need_init_hdr = true;
 		}
 
-		if (!(mango_scene_output_commit(m->scene_output, &m->pending))) {
-			if (m->hdr_enable) {
-				output_state_setup_hdr(m, true, &m->pending);
-			}
-		}
+		mango_scene_output_commit(m->scene_output, &m->pending);
+
 		wlr_output_effective_resolution(m->wlr_output, &m->m.width,
 										&m->m.height);
 	}

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1,3 +1,8 @@
+#ifdef __OpenBSD__
+#define SPAWN_MAX_ARGS 64
+#define SPAWN_MAX_TOKENS (SPAWN_MAX_ARGS - 1)
+#endif
+
 int32_t bind_to_view(const Arg *arg) {
 	if (!selmon)
 		return 0;
@@ -875,6 +880,7 @@ int32_t spawn(const Arg *arg) {
 		dup2(STDERR_FILENO, STDOUT_FILENO);
 		setsid();
 
+#ifndef __OpenBSD__
 		// 2. 对整个参数字符串进行单词展开
 		wordexp_t p;
 		if (wordexp(arg->v, &p, 0) != 0) {
@@ -889,6 +895,42 @@ int32_t spawn(const Arg *arg) {
 		wlr_log(WLR_DEBUG, "mango: execvp '%s' failed: %s\n", p.we_wordv[0],
 				strerror(errno));
 		wordfree(&p); // 释放 wordexp 分配的内存
+#else
+		int argc = 0;
+		char *last;
+		char *argv[SPAWN_MAX_ARGS];
+
+		char *token = strtok_r((char *)arg->v, " ", &last);
+
+		while (token != NULL && argc < SPAWN_MAX_TOKENS) {
+			glob_t p;
+			if (glob(token, GLOB_DOOFFS, NULL, &p) == 0 && p.gl_pathc > 0) {
+				argv[argc] = strdup(p.gl_pathv[0]);
+				globfree(&p);
+			} else {
+				argv[argc] = strdup(token);
+			}
+			argc++;
+			token = strtok(NULL, " ");
+		}
+
+		if (argc == 0) {
+			return 0;
+		}
+
+		argv[argc] = NULL;
+
+		execvp(argv[0], argv);
+
+		wlr_log(WLR_ERROR, "mango: execvp '%s' failed: %s\n",
+				argv[0] ? argv[0] : "NULL", strerror(errno));
+
+		/* Cleanup */
+		for (int i = 0; i < argc; i++) {
+			free(argv[i]);
+		}
+
+#endif
 		_exit(EXIT_FAILURE);
 	}
 	return 0;

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -911,7 +911,7 @@ int32_t spawn(const Arg *arg) {
 				argv[argc] = strdup(token);
 			}
 			argc++;
-			token = strtok(NULL, " ");
+			token = strtok_r(NULL, " ", &last);
 		}
 
 		if (argc == 0) {

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1,6 +1,5 @@
 #ifdef __OpenBSD__
 #define SPAWN_MAX_ARGS 64
-#define SPAWN_MAX_TOKENS (SPAWN_MAX_ARGS - 1)
 #endif
 
 int32_t bind_to_view(const Arg *arg) {
@@ -902,7 +901,7 @@ int32_t spawn(const Arg *arg) {
 
 		char *token = strtok_r((char *)arg->v, " ", &last);
 
-		while (token != NULL && argc < SPAWN_MAX_TOKENS) {
+		while (token != NULL && argc < SPAWN_MAX_ARGS - 1) {
 			glob_t p;
 			if (glob(token, GLOB_DOOFFS, NULL, &p) == 0 && p.gl_pathc > 0) {
 				argv[argc] = strdup(p.gl_pathv[0]);

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1,3 +1,7 @@
+#ifdef __OpenBSD__
+#define SPAWN_MAX_ARGS 64
+#endif
+
 int32_t bind_to_view(const Arg *arg) {
 	if (!selmon)
 		return 0;
@@ -1078,6 +1082,7 @@ int32_t spawn(const Arg *arg) {
 		dup2(STDERR_FILENO, STDOUT_FILENO);
 		setsid();
 
+#ifndef __OpenBSD__
 		wordexp_t p;
 		if (wordexp(arg->v, &p, 0) != 0) {
 			wlr_log(WLR_DEBUG, "mango: wordexp failed for '%s'\n",
@@ -1090,6 +1095,42 @@ int32_t spawn(const Arg *arg) {
 		wlr_log(WLR_DEBUG, "mango: execvp '%s' failed: %s\n", p.we_wordv[0],
 				strerror(errno));
 		wordfree(&p);
+#else
+		int argc = 0;
+		char *last;
+		char *argv[SPAWN_MAX_ARGS];
+
+		char *token = strtok_r((char *)arg->v, " ", &last);
+
+		while (token != NULL && argc < SPAWN_MAX_ARGS - 1) {
+			glob_t p;
+			if (glob(token, GLOB_DOOFFS, NULL, &p) == 0 && p.gl_pathc > 0) {
+				argv[argc] = strdup(p.gl_pathv[0]);
+				globfree(&p);
+			} else {
+				argv[argc] = strdup(token);
+			}
+			argc++;
+			token = strtok_r(NULL, " ", &last);
+		}
+
+		if (argc == 0) {
+			return 0;
+		}
+
+		argv[argc] = NULL;
+
+		execvp(argv[0], argv);
+
+		wlr_log(WLR_ERROR, "mango: execvp '%s' failed: %s\n",
+				argv[0] ? argv[0] : "NULL", strerror(errno));
+
+		/* Cleanup */
+		for (int i = 0; i < argc; i++) {
+			free(argv[i]);
+		}
+
+#endif
 		_exit(EXIT_FAILURE);
 	}
 	return 0;

--- a/src/ext-protocol/hdr.h
+++ b/src/ext-protocol/hdr.h
@@ -113,18 +113,21 @@ void output_state_setup_hdr(Monitor *m, bool silent,
 			if (!silent)
 				wlr_log(WLR_INFO,
 						"No 10 bit color formats supported, HDR disabled.");
-			if (!output_set_render_format(m, output_formats_8bit,
-										  ARRAY_SIZE(output_formats_8bit),
-										  state))
+			hdr_succeeded = output_set_render_format(
+				m, output_formats_8bit, ARRAY_SIZE(output_formats_8bit), state);
+			if (!hdr_succeeded) {
 				if (!silent)
-					wlr_log(WLR_ERROR, "No 8 bit color formats either!");
+					wlr_log(WLR_ERROR, "No 8 bit color formats supported!");
+			}
 		}
 	} else {
 		// 明确要求8位或自动降级
-		if (!output_set_render_format(m, output_formats_8bit,
-									  ARRAY_SIZE(output_formats_8bit), state))
+		hdr_succeeded = output_set_render_format(
+			m, output_formats_8bit, ARRAY_SIZE(output_formats_8bit), state);
+		if (!hdr_succeeded) {
 			if (!silent)
 				wlr_log(WLR_ERROR, "No 8 bit color formats supported!");
+		}
 	}
 
 	output_enable_hdr(m, state, hdr_succeeded, silent);

--- a/src/mango.c
+++ b/src/mango.c
@@ -85,7 +85,11 @@
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
+#ifndef __OpenBSD__
 #include <wordexp.h>
+#else
+#include <glob.h>
+#endif
 #include <xkbcommon/xkbcommon.h>
 #ifdef XWAYLAND
 #include <X11/Xlib.h>

--- a/src/mango.c
+++ b/src/mango.c
@@ -607,6 +607,7 @@ struct Monitor {
 	bool is_vrr_opening;
 	bool hdr_enable;
 	bool prefer_disable;
+	bool need_init_hdr;
 };
 
 typedef struct {
@@ -3464,6 +3465,7 @@ void createmon(struct wl_listener *listener, void *data) {
 	m->carousel_anim_dir = 0;
 	m->vrr_global_enable = false;
 	m->is_vrr_opening = false;
+	m->need_init_hdr = false;
 
 	m->hdr_enable = false;
 	m->prefer_disable = false;
@@ -3523,6 +3525,10 @@ void createmon(struct wl_listener *listener, void *data) {
 		wlr_output_state_set_enabled(&m->pending, true);
 	}
 
+	if (m->hdr_enable) {
+		m->need_init_hdr = true;
+	}
+
 	mango_output_commit(m);
 
 	wl_list_insert(&mons, &m->link);
@@ -3577,12 +3583,6 @@ void createmon(struct wl_listener *listener, void *data) {
 	wlr_scene_output_layout_add_output(scene_layout, layout_output,
 									   m->scene_output);
 
-	if (m->hdr_enable) {
-		output_state_setup_hdr(m, false, &m->pending);
-	}
-
-	mango_scene_output_commit(m->scene_output, &m->pending);
-
 	wlr_output_effective_resolution(m->wlr_output, &m->m.width, &m->m.height);
 
 	if (config.blur) {
@@ -3598,6 +3598,8 @@ void createmon(struct wl_listener *listener, void *data) {
 	for (i = 1; i <= LENGTH(tags); i++) {
 		add_workspace_by_tag(i, m);
 	}
+
+	wlr_output_schedule_frame(m->wlr_output);
 
 	printstatus(IPC_WATCH_ARRANGGE);
 }

--- a/src/mango.c
+++ b/src/mango.c
@@ -91,7 +91,11 @@
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
+#ifndef __OpenBSD__
 #include <wordexp.h>
+#else
+#include <glob.h>
+#endif
 #include <xkbcommon/xkbcommon.h>
 #ifdef XWAYLAND
 #include <X11/Xlib.h>


### PR DESCRIPTION
OpenBSD does not have wordexp, therefore we need to add a reasonable approximation of mango's standard behavior when spawning commands.

Thank you in advance for considering it.