### PR TITLE
fix : ensure the current dekstop is mango before executing ipc dispatch

### DIFF
--- a/mmsg/mmsg.c
+++ b/mmsg/mmsg.c
@@ -546,6 +546,15 @@ static void usage(void) {
 }
 
 int32_t main(int32_t argc, char *argv[]) {
+
+	const char *env_XDG_DEKSTOP = getenv("XDG_CURRENT_DESKTOP");
+
+	if (!env_XDG_DEKSTOP || strcmp(env_XDG_DEKSTOP, "mango")) {
+		fprintf(stderr, "wrong dekstop, wanted 'mango' have '%s'\n",
+				env_XDG_DEKSTOP);
+		exit(EXIT_FAILURE);
+	}
+
 	ARGBEGIN {
 	case 'q':
 		qflag = 1;

--- a/mmsg/mmsg.c
+++ b/mmsg/mmsg.c
@@ -549,7 +549,11 @@ int32_t main(int32_t argc, char *argv[]) {
 
 	const char *env_XDG_DEKSTOP = getenv("XDG_CURRENT_DESKTOP");
 
-	if (!env_XDG_DEKSTOP || strcmp(env_XDG_DEKSTOP, "mango")) {
+	/*
+	 * https://specifications.freedesktop.org/mime-apps/latest/file.html
+	 * can be more than just 'mango' but 'mango,mangowm,wlroots'
+	 */
+	if (!env_XDG_DEKSTOP || !strstr(env_XDG_DEKSTOP, "mango")) {
 		fprintf(stderr, "wrong dekstop, wanted 'mango' have '%s'\n",
 				env_XDG_DEKSTOP);
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
This commit fix a issue that if you run `mmsg [flag] [param]` with a valide command on a compositor or a wm which is not mango but have mango install mmsg segfault.

Check if `XDG_CURRENT_DEKSTOP` is mango, then execute it, if not return a error and close the program

Test under Artix Linux x86_64