### PR TITLE
pointer constraint handling for layer-shell surfaces (lan-mouse input retain issue)

### DIFF
--- a/src/mango.c
+++ b/src/mango.c
@@ -4384,20 +4384,23 @@ void motionnotify(uint32_t time, struct wlr_input_device *device, double dx,
 
 		if (active_constraint && cursor_mode != CurResize &&
 			cursor_mode != CurMove) {
-			toplevel_from_wlr_surface(active_constraint->surface, &c, NULL);
-			if (c && active_constraint->surface ==
-						 seat->pointer_state.focused_surface) {
-				sx = cursor->x - c->geom.x - c->bw;
-				sy = cursor->y - c->geom.y - c->bw;
-				if (wlr_region_confine(&active_constraint->region, sx, sy,
-									   sx + dx, sy + dy, &sx_confined,
-									   &sy_confined)) {
-					dx = sx_confined - sx;
-					dy = sy_confined - sy;
-				}
+			if (active_constraint->surface ==
+				seat->pointer_state.focused_surface) {
 
 				if (active_constraint->type == WLR_POINTER_CONSTRAINT_V1_LOCKED)
 					return;
+
+				toplevel_from_wlr_surface(active_constraint->surface, &c, NULL);
+				if (c) {
+					sx = cursor->x - c->geom.x - c->bw;
+					sy = cursor->y - c->geom.y - c->bw;
+					if (wlr_region_confine(&active_constraint->region, sx, sy,
+										   sx + dx, sy + dy, &sx_confined,
+										   &sy_confined)) {
+						dx = sx_confined - sx;
+						dy = sy_confined - sy;
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
#### Purpose:
I am a heavy user of input capture software like Synergy, deskflow and [lan-mouse](https://github.com/feschber/lan-mouse). I'm in love with what mango offers but there was this little detail not letting me be 100% happy. 
lan-mouse worked partially, entering the second PC's screen properly. But when moving the mouse back, mango didn't wait for input release from lan-mouse and immediately released the input, moving the cursor back to the main PC's screen.

#### Problem:
lan-mouse's capture backend uses a layer-shell surface, not a toplevel window. toplevel_from_wlr_surface() returns NULL for layer-shell surfaces. This is because "if (c && ...)" block is always NULL.

#### Solution:
Reordering the checks in the block this way fixes the issue that lan-mouse has, releasing the input on an actual focus loss, not on loss of border friction.

