### PR TITLE
feat(ipc): add per-client tag event to zdwl_ipc_output_v2 v3

### DIFF
--- a/protocols/dwl-ipc-unstable-v2.xml
+++ b/protocols/dwl-ipc-unstable-v2.xml
@@ -19,7 +19,7 @@ I would probably just submit raphi's patchset but I don't think that would be po
       reset.
   </description>
 
-  <interface name="zdwl_ipc_manager_v2" version="2">
+  <interface name="zdwl_ipc_manager_v2" version="3">
     <description summary="manage dwl state">
       This interface is exposed as a global in wl_registry.
 
@@ -60,7 +60,7 @@ I would probably just submit raphi's patchset but I don't think that would be po
     </event>
   </interface>
 
-  <interface name="zdwl_ipc_output_v2" version="2">
+  <interface name="zdwl_ipc_output_v2" version="3">
     <description summary="control dwl output">
       Observe and control a dwl output.
 
@@ -126,6 +126,17 @@ I would probably just submit raphi's patchset but I don't think that would be po
         Indicates the appid has changed.
       </description>
       <arg name="appid" type="string" summary="The new appid."/>
+    </event>
+
+    <event name="client" since="3">
+        <description summary="Reports a client and its tag mask.">
+            Reports a single managed client on this output, with its appid, title,
+            and tag bitmask. Fired once per client per state-update batch, after
+            all tag events and before frame.
+        </description>
+           <arg name="appid" type="string" summary="The client's appid."/>
+           <arg name="title" type="string" summary="The client's title."/>
+           <arg name="tagmask" type="uint" summary="Bitmask of tags this client occupies."/>
     </event>
 
     <event name="layout_symbol" since="1">

--- a/src/ext-protocol/dwl-ipc.h
+++ b/src/ext-protocol/dwl-ipc.h
@@ -212,6 +212,21 @@ void dwl_ipc_output_printstatus_to(DwlIpcOutput *ipc_output) {
 	}
 
 	zdwl_ipc_output_v2_send_frame(ipc_output->resource);
+
+  //recently added
+  if (wl_resource_get_version(ipc_output->resource) >= ZDWL_IPC_OUTPUT_V2_CLIENT_SINCE_VERSION) {
+        const char *c_appid, *c_title;
+        wl_list_for_each(c, &clients, link) {
+            if (c->mon != monitor)
+                continue;
+            c_appid = client_get_appid(c);
+            c_title = client_get_title(c);
+            zdwl_ipc_output_v2_send_client(ipc_output->resource,
+                c_appid ? c_appid : broken,
+                c_title ? c_title : broken,
+                c->tags);
+        }
+   }
 }
 
 void dwl_ipc_output_set_client_tags(struct wl_client *client,

--- a/src/mango.c
+++ b/src/mango.c
@@ -5802,7 +5802,8 @@ void setup(void) {
 		wlr_log(WLR_INFO, "VR will not be available.");
 	}
 
-	wl_global_create(dpy, &zdwl_ipc_manager_v2_interface, 2, NULL,
+
+  wl_global_create(dpy, &zdwl_ipc_manager_v2_interface, 3, NULL,
 					 dwl_ipc_manager_bind);
 
 	// 创建顶层管理句柄


### PR DESCRIPTION
# Proposal: per-client tag identification via new `client` event in zdwl_ipc_output_v2

## The gap

Mango's IPC currently exposes per-tag client *counts* via the existing `tag` event
on `zdwl_ipc_output_v2`, but no way to associate clients with their tags.
`zwlr_foreign_toplevel_manager_v1` reports all toplevels with their appid/title
but no tag information; `ext_workspace_manager_v1` reports tag state but no
toplevel association. The two streams are disjoint, so consumers (status bars,
custom launchers, scripted layouts) can know "tag 3 has 2 windows" or
"these toplevels exist," but not "which windows are on tag 3."

The information exists internally — every `Client` struct has a `tags` bitmask —
it just isn't exposed.

## Reproduction

Diagnostic client binding both protocols against an unmodified mango:

Tag 1 active, three windows open across multiple tags:
```
toplevel: title="Mozilla Firefox"     state=[]
toplevel: title="firefox ~/D/p/mtags" state=[]
toplevel: title="~/D/p/mtags"         state=[activated]
workspace 1: state=active
```

Tag 4 active, same three windows:
```
toplevel: title="Mozilla Firefox"     state=[]
toplevel: title="firefox ~/D/p/mtags" state=[]
toplevel: title="~/D/p/mtags"         state=[]
workspace 4: state=active
```

The toplevel list is identical. There's no way for a consumer to determine which
window lives on which tag. The output came via [mtags](https://github.com/dashdashRod/mtags),
a small Wayland test client that connects to the compositor, binds the available
workspace/toplevel/dwl-ipc protocols, listens for events, and prints workspace, window,
and tag/client state for debugging.


## Proposal

Add a `client` event to `zdwl_ipc_output_v2` (bumped to interface version 3)
that fires once per managed client per output during the existing state-update
batch, after the per-tag events and before `frame`:

```xml
<event name="client" since="3">
  <description summary="Reports a client and its tag mask.">
    Reports a single managed client on this output, with its appid, title,
    and tag bitmask.
  </description>
  <arg name="appid" type="string"/>
  <arg name="title" type="string"/>
  <arg name="tagmask" type="uint"/>
</event>
```

## Verification

Working prototype on the fork. Same diagnostic client, this time bound to `zdwl_ipc_manager_v2 v3`. Two foot terminals on tag 1:
Implementation is localized, one event definition in the XML, one loop in
`dwl_ipc_output_printstatus_to`, plus the version bump where the global is
created. Checkout the diff in this fork [fork](https://github.com/dashdashRod/mango/tree/Experimental)


```
ipc client: appid="foot" title="~/D/m/mango" tagmask=0x1
ipc client: appid="foot" title="./mtags > NEWBRANDRE ~/D/p/m/build" tagmask=0x1
```

After moving one to tag 4 via `mmsg -d tag,4`:

```
ipc client: appid="foot" title="~/D/m/mango" tagmask=0x8
```

Bitmask correlates correctly with tag membership (0x1 = tag 1, 0x8 = tag 4).

<details>
<summary>Full mtags output </summary>

```
bound: zdwl_ipc_manager_v2 v3
bound: zwlr_foreign_toplevel_manager_v1 v3
bound: ext_workspace_manager_v1 v1
bound: wl_output v4
ipc_output: bound
ipc: tags amount=9
new toplevel: 0x2892e7d0
new toplevel: 0x289314d0
  toplevel 0x2892e7d0: title="./mtags > NEWBRANDRE ~/D/p/m/build"
  toplevel 0x2892e7d0: app_id="foot"
  toplevel 0x2892e7d0: state=[activated ]
  toplevel 0x2892e7d0: done
  toplevel 0x289314d0: title="~/D/m/mango"
  toplevel 0x289314d0: app_id="foot"
  toplevel 0x289314d0: state=[]
  toplevel 0x289314d0: done
new group: 0x289336e0
new workspace: 0x28933930
  workspace 0x28933930: name=9
  workspace 0x28933930: id=9
  workspace 0x28933930: state=hidden 
group 0x289336e0: workspace 0x28933930 entered
new workspace: 0x28933f40
  workspace 0x28933f40: name=8
  workspace 0x28933f40: id=8
  workspace 0x28933f40: state=hidden 
group 0x289336e0: workspace 0x28933f40 entered
new workspace: 0x28934550
  workspace 0x28934550: name=7
  workspace 0x28934550: id=7
  workspace 0x28934550: state=hidden 
group 0x289336e0: workspace 0x28934550 entered
new workspace: 0x28934b60
  workspace 0x28934b60: name=6
  workspace 0x28934b60: id=6
  workspace 0x28934b60: state=hidden 
group 0x289336e0: workspace 0x28934b60 entered
new workspace: 0x28935170
  workspace 0x28935170: name=5
  workspace 0x28935170: id=5
  workspace 0x28935170: state=hidden 
group 0x289336e0: workspace 0x28935170 entered
new workspace: 0x28935810
  workspace 0x28935810: name=4
  workspace 0x28935810: id=4
  workspace 0x28935810: state=
group 0x289336e0: workspace 0x28935810 entered
new workspace: 0x28935e20
  workspace 0x28935e20: name=3
  workspace 0x28935e20: id=3
  workspace 0x28935e20: state=
group 0x289336e0: workspace 0x28935e20 entered
new workspace: 0x28936430
  workspace 0x28936430: name=2
  workspace 0x28936430: id=2
  workspace 0x28936430: state=
group 0x289336e0: workspace 0x28936430 entered
new workspace: 0x28936a40
  workspace 0x28936a40: name=1
  workspace 0x28936a40: id=1
  workspace 0x28936a40: state=active 
group 0x289336e0: workspace 0x28936a40 entered
--- workspace state complete ---
  toplevel 0x289314d0: output_enter 0x289311f0
  toplevel 0x2892e7d0: output_enter 0x289311f0
  --- ipc frame ---
  ipc client: appid="foot" title="~/D/m/mango" tagmask=0x1
  ipc client: appid="foot" title="./mtags > NEWBRANDRE ~/D/p/m/build" tagmask=0x1
--- workspace state complete ---
  toplevel 0x289314d0: done
  toplevel 0x2892e7d0: done
```


</details>

## Notes

#### The event reports `appid`/`title`/`tagmask`. More fields (pid, floating/fullscreen, monitor) can be added later — Wayland version bumps are backward-compatible, so older clients just ignore newer events.