### PR TITLE
feat: add sleep_monitor command with wake-on-input

### DIFF
--- a/docs/bindings/keys.md
+++ b/docs/bindings/keys.md
@@ -168,6 +168,7 @@ bindr=Super,Super_L,spawn,rofi -show run
 | `disable_monitor` | `monitor_spec` | Shutdown monitor. Accepts a [monitor spec](/docs/configuration/monitors#monitor-spec-format). |
 | `enable_monitor` | `monitor_spec` | Power on monitor. Accepts a [monitor spec](/docs/configuration/monitors#monitor-spec-format). |
 | `toggle_monitor` | `monitor_spec` | Toggle monitor power. Accepts a [monitor spec](/docs/configuration/monitors#monitor-spec-format). |
+| `sleep_monitor` | `monitor_spec` | Turn off monitor and wake it automatically on the next keypress or mouse movement. Accepts a [monitor spec](/docs/configuration/monitors#monitor-spec-format). |
 
 ### Media Controls
 

--- a/docs/configuration/monitors.md
+++ b/docs/configuration/monitors.md
@@ -67,7 +67,7 @@ monitorrule=name:HEADLESS-.*,width:1920,height:1080,refresh:60,x:1926,y:0,scale:
 
 ## Monitor Spec Format
 
-Several commands (`focusmon`, `tagmon`, `disable_monitor`, `enable_monitor`, `toggle_monitor`, `viewcrossmon`, `tagcrossmon`) accept a **monitor_spec** string to identify a monitor.
+Several commands (`focusmon`, `tagmon`, `disable_monitor`, `enable_monitor`, `toggle_monitor`, `sleep_monitor`, `viewcrossmon`, `tagcrossmon`) accept a **monitor_spec** string to identify a monitor.
 
 **Format:**
 
@@ -173,6 +173,9 @@ mmsg -d enable_monitor,eDP-1
 
 # Toggle
 mmsg -d toggle_monitor,eDP-1
+
+# Turn off and wake automatically on next keypress or mouse movement
+mmsg -d sleep_monitor,eDP-1
 ```
 
 You can also use `wlr-randr` for monitor management:

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -1209,6 +1209,9 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 	} else if (strcmp(func_name, "toggle_monitor") == 0) {
 		func = toggle_monitor;
 		(*arg).v = strdup(arg_value);
+	} else if (strcmp(func_name, "sleep_monitor") == 0) {
+		func = sleep_monitor;
+		(*arg).v = strdup(arg_value);
 	} else if (strcmp(func_name, "scroller_stack") == 0) {
 		func = scroller_stack;
 		(*arg).i = parse_direction(arg_value);

--- a/src/dispatch/bind_declare.h
+++ b/src/dispatch/bind_declare.h
@@ -69,5 +69,6 @@ int32_t setoption(const Arg *arg);
 int32_t disable_monitor(const Arg *arg);
 int32_t enable_monitor(const Arg *arg);
 int32_t toggle_monitor(const Arg *arg);
+int32_t sleep_monitor(const Arg *arg);
 int32_t scroller_stack(const Arg *arg);
 int32_t toggle_all_floating(const Arg *arg);

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1727,67 +1727,27 @@ int32_t toggleoverview(const Arg *arg) {
 	return 0;
 }
 
-int32_t disable_monitor(const Arg *arg) {
+/* enabled: 1 = on, 0 = off, -1 = toggle */
+static void set_monitor_enabled(const Arg *arg, int enabled, int wake_on_input) {
 	Monitor *m = NULL;
 	struct wlr_output_state state = {0};
 	wl_list_for_each(m, &mons, link) {
 		if (match_monitor_spec(arg->v, m)) {
-			wlr_output_state_set_enabled(&state, false);
+			int new_enabled = (enabled < 0) ? !m->wlr_output->enabled : enabled;
+			wlr_output_state_set_enabled(&state, new_enabled);
 			wlr_output_commit_state(m->wlr_output, &state);
-			m->asleep = 1;
+			m->asleep = !new_enabled;
+			m->wake_on_input = wake_on_input;
 			updatemons(NULL, NULL);
 			break;
 		}
 	}
-	return 0;
 }
 
-int32_t enable_monitor(const Arg *arg) {
-	Monitor *m = NULL;
-	struct wlr_output_state state = {0};
-	wl_list_for_each(m, &mons, link) {
-		if (match_monitor_spec(arg->v, m)) {
-			wlr_output_state_set_enabled(&state, true);
-			wlr_output_commit_state(m->wlr_output, &state);
-			m->asleep = 0;
-			updatemons(NULL, NULL);
-			break;
-		}
-	}
-	return 0;
-}
-
-int32_t toggle_monitor(const Arg *arg) {
-	Monitor *m = NULL;
-	struct wlr_output_state state = {0};
-	wl_list_for_each(m, &mons, link) {
-		if (match_monitor_spec(arg->v, m)) {
-			wlr_output_state_set_enabled(&state, !m->wlr_output->enabled);
-			wlr_output_commit_state(m->wlr_output, &state);
-			m->asleep = !m->wlr_output->enabled;
-			updatemons(NULL, NULL);
-			break;
-		}
-	}
-	return 0;
-}
-
-/* Turns off a monitor and re-enables it on the next keypress or mouse input. */
-int32_t sleep_monitor(const Arg *arg) {
-	Monitor *m = NULL;
-	struct wlr_output_state state = {0};
-	wl_list_for_each(m, &mons, link) {
-		if (match_monitor_spec(arg->v, m)) {
-			wlr_output_state_set_enabled(&state, false);
-			wlr_output_commit_state(m->wlr_output, &state);
-			m->asleep = 1;
-			m->wake_on_input = 1;
-			updatemons(NULL, NULL);
-			break;
-		}
-	}
-	return 0;
-}
+int32_t disable_monitor(const Arg *arg) { set_monitor_enabled(arg, 0, 0); return 0; }
+int32_t enable_monitor(const Arg *arg)  { set_monitor_enabled(arg, 1, 0); return 0; }
+int32_t toggle_monitor(const Arg *arg)  { set_monitor_enabled(arg, -1, 0); return 0; }
+int32_t sleep_monitor(const Arg *arg)   { set_monitor_enabled(arg, 0, 1); return 0; }
 
 int32_t scroller_apply_stack(Client *c, Client *target_client,
 							 int32_t direction) {

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1772,6 +1772,23 @@ int32_t toggle_monitor(const Arg *arg) {
 	return 0;
 }
 
+/* Turns off a monitor and re-enables it on the next keypress or mouse input. */
+int32_t sleep_monitor(const Arg *arg) {
+	Monitor *m = NULL;
+	struct wlr_output_state state = {0};
+	wl_list_for_each(m, &mons, link) {
+		if (match_monitor_spec(arg->v, m)) {
+			wlr_output_state_set_enabled(&state, false);
+			wlr_output_commit_state(m->wlr_output, &state);
+			m->asleep = 1;
+			m->wake_on_input = 1;
+			updatemons(NULL, NULL);
+			break;
+		}
+	}
+	return 0;
+}
+
 int32_t scroller_apply_stack(Client *c, Client *target_client,
 							 int32_t direction) {
 

--- a/src/mango.c
+++ b/src/mango.c
@@ -537,6 +537,7 @@ struct Monitor {
 	int32_t isoverview;
 	int32_t is_in_hotarea;
 	int32_t asleep;
+	int32_t wake_on_input;
 	uint32_t visible_clients;
 	uint32_t visible_tiling_clients;
 	uint32_t visible_scroll_tiling_clients;
@@ -751,6 +752,7 @@ static void set_rect_size(struct wlr_scene_rect *rect, int32_t width,
 						  int32_t height);
 static Client *center_tiled_select(Monitor *m);
 static void handlecursoractivity(void);
+static void wakesleepingmons(void);
 static int32_t hidecursor(void *data);
 static bool check_hit_no_border(Client *c);
 static void reset_keyboard_layout(void);
@@ -2228,6 +2230,9 @@ buttonpress(struct wl_listener *listener, void *data) {
 	if (check_trackpad_disabled(event->pointer)) {
 		return;
 	}
+
+	if (event->state == WL_POINTER_BUTTON_STATE_PRESSED)
+		wakesleepingmons();
 
 	switch (event->state) {
 	case WL_POINTER_BUTTON_STATE_PRESSED:
@@ -4053,6 +4058,9 @@ void keypress(struct wl_listener *listener, void *data) {
 
 	wlr_idle_notifier_v1_notify_activity(idle_notifier, seat);
 
+	if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED)
+		wakesleepingmons();
+
 	// ov tab mode detect moe key release
 	if (config.ov_tab_mode && !locked && group == kb_group &&
 		event->state == WL_KEYBOARD_KEY_STATE_RELEASED &&
@@ -4536,6 +4544,7 @@ void motionnotify(uint32_t time, struct wlr_input_device *device, double dx,
 
 	/* time is 0 in internal calls meant to restore pointer focus. */
 	if (time) {
+		wakesleepingmons();
 		wlr_relative_pointer_manager_v1_send_relative_motion(
 			relative_pointer_mgr, seat, (uint64_t)time * 1000, dx, dy,
 			dx_unaccel, dy_unaccel);
@@ -6148,6 +6157,22 @@ void handlecursoractivity(void) {
 	else if (last_cursor.surface)
 		wlr_cursor_set_surface(cursor, last_cursor.surface,
 							   last_cursor.hotspot_x, last_cursor.hotspot_y);
+}
+
+void wakesleepingmons(void) {
+	Monitor *m;
+	struct wlr_output_state state;
+	wl_list_for_each(m, &mons, link) {
+		if (!m->wake_on_input)
+			continue;
+		wlr_output_state_init(&state);
+		wlr_output_state_set_enabled(&state, true);
+		wlr_output_commit_state(m->wlr_output, &state);
+		wlr_output_state_finish(&state);
+		m->asleep = 0;
+		m->wake_on_input = 0;
+		updatemons(NULL, NULL);
+	}
 }
 
 int32_t hidecursor(void *data) {


### PR DESCRIPTION
  Closes #780.

  Adds a sleep_monitor command that turns off a specific monitor and
  automatically re-enables it on the next keypress or mouse movement.

  Unlike disable_monitor, no explicit enable_monitor call is needed — the
  monitor wakes itself on any input event.

  Usage:
  sleep_monitor,eDP-1

  Implementation:
  - Adds wake_on_input flag to struct Monitor
  - sleep_monitor() disables the output and sets the flag
  - wakesleepingmons() is called in keypress, buttonpress, and motionnotify
  to re-enable any flagged monitors on the next real input event