### PR TITLE
Set foreign_toplevel of unfocused monitor windows to false

### DIFF
--- a/src/mango.c
+++ b/src/mango.c
@@ -3747,8 +3747,14 @@ void focusclient(Client *c, int32_t lift) {
 	wl_list_for_each(um, &mons, link) {
 		if (um->wlr_output->enabled && um != selmon && um->sel &&
 			!um->sel->iskilling && um->sel->isfocusing) {
+
 			um->sel->isfocusing = false;
 			client_set_unfocused_opacity_animation(um->sel);
+
+			if (um->sel->foreign_toplevel) {
+				wlr_foreign_toplevel_handle_v1_set_activated(
+					um->sel->foreign_toplevel, false);
+			}
 		}
 	}
 


### PR DESCRIPTION
I don't know much about wlroots so I'm not sure if this is the best way to do it.

Issue #900 