### PR TITLE
Updated flake.lock nixpkgs input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750386251,
-        "narHash": "sha256-1ovgdmuDYVo5OUC5NzdF+V4zx2uT8RtsgZahxidBTyw=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "076e8c6678d8c54204abcb4b1b14c366835a58bb",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Made because project wasn't building (with `nix build`) due to the updated name for `libxcb-wm`.

Project was not building with
```nix
error: evaluation aborted with the following error message: 'lib.customisation.callPackageWith: Function called without required argument "libxcb-wm" at /nix/store/779im7kk8sq23irpb28gbbirfs2kjg3n-source/nix/default.nix:14'
```

Fixed by updating the nixpkgs input, which renamed the package to `libxcb-wm`.