### PR TITLE
fix: fix crash when disabling outputs with scratchpad clients

### DIFF
--- a/src/fetch/client.h
+++ b/src/fetch/client.h
@@ -5,7 +5,8 @@ bool check_hit_no_border(Client *c) {
 	}
 
 	if (c->mon && !c->mon->isoverview &&
-		c->mon->pertag->no_render_border[get_tags_first_tag_num(c->tags)]) {
+		c->mon->pertag->no_render_border[get_tags_first_tag_num(
+			c->tags ? c->tags : c->mon->tagset[c->mon->seltags])]) {
 		hit_no_border = true;
 	}
 


### PR DESCRIPTION
## Summary

Fix a crash that could happen while disabling an output when a scratchpad/minimized client with `tags == 0` was present.

## Problem

When an output is disabled, `updatemons()` may be re-entered through output layout change handling.
During that transient state, `selmon` can be `NULL`.

`check_hit_no_border()` called `get_tags_first_tag_num(c->tags)`.
For scratchpad-style clients, `c->tags` may be `0`, which made `get_tags_first_tag_num()` fall back to `selmon->pertag->curtag`.
If this happened while `selmon == NULL`, Mango crashed.

## Steps to Reproduce

1. Start Mango with two outputs, such as `DP-1` and `HDMI-A-1`.
2. Create a scratchpad/minimized client.
3. Move the pointer onto the output that will be disabled.
4. Disable that output: `wlr-randr --output HDMI-A-1 --off`

The crash was easier to reproduce when the pointer was on the output being disabled, likely because that output was still the selected monitor while the output layout was being updated.

## Fix

Use the client’s own monitor tagset as the fallback when checking no_render_border for a client with tags == 0.

This keeps the border decision tied to c->mon and avoids depending on global selmon during output teardown/reconfiguration.
