### PR TITLE
fix: sync foreign toplevel visibility with tags

### DIFF
--- a/src/ext-protocol/foreign-toplevel.h
+++ b/src/ext-protocol/foreign-toplevel.h
@@ -2,6 +2,45 @@
 
 static struct wlr_foreign_toplevel_manager_v1 *foreign_toplevel_manager;
 
+static bool foreign_toplevel_should_enter_output(Client *c) {
+	if (!c || !c->foreign_toplevel || !c->mon || !c->mon->wlr_output ||
+		!c->mon->wlr_output->enabled || !client_surface(c)->mapped ||
+		c->iskilling)
+		return false;
+
+	if (c->isglobal || c->isunglobal)
+		return true;
+
+	uint32_t taskbar_tags = c->isminimized ? c->mini_restore_tag : c->tags;
+	return taskbar_tags & c->mon->tagset[c->mon->seltags];
+}
+
+static void sync_foreign_toplevel_output(Client *c) {
+	if (!c || !c->foreign_toplevel || !c->mon || !c->mon->wlr_output)
+		return;
+
+	bool should_enter = foreign_toplevel_should_enter_output(c);
+
+	if (should_enter && !c->foreign_toplevel_output_entered) {
+		wlr_foreign_toplevel_handle_v1_output_enter(c->foreign_toplevel,
+													c->mon->wlr_output);
+		c->foreign_toplevel_output_entered = true;
+	} else if (!should_enter && c->foreign_toplevel_output_entered) {
+		wlr_foreign_toplevel_handle_v1_output_leave(c->foreign_toplevel,
+													c->mon->wlr_output);
+		c->foreign_toplevel_output_entered = false;
+	}
+}
+
+static void sync_foreign_toplevel_outputs(Monitor *m) {
+	Client *c = NULL;
+
+	wl_list_for_each(c, &clients, link) {
+		if (c && c->mon == m)
+			sync_foreign_toplevel_output(c);
+	}
+}
+
 void handle_foreign_activate_request(struct wl_listener *listener, void *data) {
 	Client *c = wl_container_of(listener, c, foreign_activate_request);
 	uint32_t target;
@@ -99,12 +138,14 @@ void handle_foreign_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&c->foreign_close_request.link);
 	wl_list_remove(&c->foreign_destroy.link);
 	c->foreign_toplevel = NULL;
+	c->foreign_toplevel_output_entered = false;
 }
 
 void add_foreign_toplevel(Client *c) {
 	if (!c || !c->mon || !c->mon->wlr_output || !c->mon->wlr_output->enabled)
 		return;
 
+	c->foreign_toplevel_output_entered = false;
 	c->foreign_toplevel =
 		wlr_foreign_toplevel_handle_v1_create(foreign_toplevel_manager);
 	// 监听来自外部对于窗口的事件请求
@@ -134,9 +175,7 @@ void add_foreign_toplevel(Client *c) {
 		if (title)
 			wlr_foreign_toplevel_handle_v1_set_title(c->foreign_toplevel,
 													 title);
-		// 设置外部顶层句柄的显示监视器为当前监视器
-		wlr_foreign_toplevel_handle_v1_output_enter(c->foreign_toplevel,
-													c->mon->wlr_output);
+		sync_foreign_toplevel_output(c);
 	}
 }
 
@@ -152,11 +191,12 @@ void reset_foreign_tolevel(Client *c, Monitor *oldmon, Monitor *newmon) {
 	if (oldmon == newmon)
 		return;
 
-	if (oldmon)
+	if (oldmon && c->foreign_toplevel_output_entered) {
 		wlr_foreign_toplevel_handle_v1_output_leave(c->foreign_toplevel,
 													oldmon->wlr_output);
+		c->foreign_toplevel_output_entered = false;
+	}
 
 	if (newmon)
-		wlr_foreign_toplevel_handle_v1_output_enter(c->foreign_toplevel,
-													newmon->wlr_output);
+		sync_foreign_toplevel_output(c);
 }

--- a/src/mango.c
+++ b/src/mango.c
@@ -351,6 +351,7 @@ struct Client {
 	bool dirty;
 	uint32_t configure_serial;
 	struct wlr_foreign_toplevel_handle_v1 *foreign_toplevel;
+	bool foreign_toplevel_output_entered;
 	int32_t isfloating, isurgent, isfullscreen, isfakefullscreen,
 		need_float_size_reduce, isminimized, isoverlay, isnosizehint,
 		ignore_maximize, ignore_minimize, indleinhibit_when_focus;
@@ -1232,8 +1233,11 @@ void swallow(Client *c, Client *w) {
 	wl_list_insert(&w->flink, &c->flink);
 
 	if (w->foreign_toplevel) {
-		wlr_foreign_toplevel_handle_v1_output_leave(w->foreign_toplevel,
-													w->mon->wlr_output);
+		if (w->foreign_toplevel_output_entered) {
+			wlr_foreign_toplevel_handle_v1_output_leave(w->foreign_toplevel,
+														w->mon->wlr_output);
+			w->foreign_toplevel_output_entered = false;
+		}
 		wlr_foreign_toplevel_handle_v1_destroy(w->foreign_toplevel);
 		w->foreign_toplevel = NULL;
 	}
@@ -1245,8 +1249,7 @@ void swallow(Client *c, Client *w) {
 	if (!c->foreign_toplevel && c->mon)
 		add_foreign_toplevel(c);
 	else if (c->foreign_toplevel && c->mon) {
-		wlr_foreign_toplevel_handle_v1_output_enter(c->foreign_toplevel,
-													c->mon->wlr_output);
+		sync_foreign_toplevel_output(c);
 	}
 
 	client_pending_fullscreen_state(c, w->isfullscreen);
@@ -2581,8 +2584,11 @@ void closemon(Monitor *m) {
 
 			if (selmon == NULL) {
 				if (c->foreign_toplevel) {
-					wlr_foreign_toplevel_handle_v1_output_leave(
-						c->foreign_toplevel, c->mon->wlr_output);
+					if (c->foreign_toplevel_output_entered) {
+						wlr_foreign_toplevel_handle_v1_output_leave(
+							c->foreign_toplevel, c->mon->wlr_output);
+						c->foreign_toplevel_output_entered = false;
+					}
 					wlr_foreign_toplevel_handle_v1_destroy(c->foreign_toplevel);
 					c->foreign_toplevel = NULL;
 				}
@@ -4513,6 +4519,7 @@ mapnotify(struct wl_listener *listener, void *data) {
 	// make sure the animation is open type
 	c->is_pending_open_animation = true;
 	resize(c, c->geom, 0);
+	sync_foreign_toplevel_output(c);
 	printstatus();
 }
 
@@ -4541,6 +4548,7 @@ void unminimize(Client *c) {
 		c->is_in_scratchpad = 0;
 		c->isnamedscratchpad = 0;
 		setborder_color(c);
+		sync_foreign_toplevel_output(c);
 		return;
 	}
 
@@ -4551,6 +4559,7 @@ void unminimize(Client *c) {
 		c->isnamedscratchpad = 0;
 		setborder_color(c);
 		arrange(c->mon, false, false);
+		sync_foreign_toplevel_output(c);
 		return;
 	}
 }
@@ -4569,6 +4578,7 @@ void set_minimized(Client *c) {
 	c->is_scratchpad_show = 0;
 	focusclient(focustop(selmon), 1);
 	arrange(c->mon, false, false);
+	sync_foreign_toplevel_output(c);
 
 	if (c->foreign_toplevel)
 		wlr_foreign_toplevel_handle_v1_set_activated(c->foreign_toplevel,
@@ -5637,6 +5647,7 @@ void setmon(Client *c, Monitor *m, uint32_t newtags, bool focus) {
 		check_match_tag_floating_rule(c, m);
 		setfloating(c, c->isfloating);
 		setfullscreen(c, c->isfullscreen); /* This will call arrange(c->mon) */
+		sync_foreign_toplevel_output(c);
 	}
 
 	if (focus && !client_is_x11_popup(c)) {
@@ -5678,6 +5689,7 @@ void show_hide_client(Client *c) {
 	}
 	client_pending_minimized_state(c, 0);
 	focusclient(c, 1);
+	sync_foreign_toplevel_output(c);
 
 	if (c->foreign_toplevel)
 		wlr_foreign_toplevel_handle_v1_set_activated(c->foreign_toplevel, true);
@@ -6608,6 +6620,7 @@ toggleseltags:
 	if (changefocus)
 		focusclient(focustop(m), 1);
 	arrange(m, want_animation, true);
+	sync_foreign_toplevel_outputs(m);
 	printstatus();
 }
 


### PR DESCRIPTION
## Summary
- Advertise foreign toplevels to outputs only when their tags are visible on the selected tag set.
- Keep minimized clients advertised on their restore tag so taskbars can still restore them.
- Use foreign-toplevel output enter/leave events so taskbars like Waybar do not need compositor-specific IPC.

## Test plan
- Built locally through the Arch package workflow.
- Verified the PR diff is limited to `src/mango.c` and `src/ext-protocol/foreign-toplevel.h`.

Made with [Cursor](https://cursor.com)