### PR TITLE
fix: pin scenefx to resolve deprecation warning

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,6 +49,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1750605355,
+        "narHash": "sha256-xT8cPLTxlktxI9vSdoBlAVK7dXgd8IK59j7ZwzkkhnI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3078b9a9e75f1790e6d6ef9955fdc6a2d1740cc6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
@@ -58,9 +74,7 @@
     },
     "scenefx": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1750785057,
@@ -73,6 +87,7 @@
       "original": {
         "owner": "wlrfx",
         "repo": "scenefx",
+        "rev": "3a6cfb12e4ba97b43326357d14f7b3e40897adfc",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     scenefx = {
-      url = "github:wlrfx/scenefx";
-      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:wlrfx/scenefx?rev=3a6cfb12e4ba97b43326357d14f7b3e40897adfc";
     };
   };
 


### PR DESCRIPTION
I pinned scenefx to the hash currently used in the flake.lock file and removed the nixpkgs-unstable input (so it uses the nixpkgs hash that it was originally built against). This removes the deprecation warning when built on NixOS.

Should resolve #886 and avoids the issues that #821 ran up against.