### PR TITLE
fix: don't remove the leaf from the tree when fullscreening 

### DIFF
--- a/src/layout/dwindle.h
+++ b/src/layout/dwindle.h
@@ -257,8 +257,11 @@ static void dwindle_assign(DwindleNode *node, int32_t ax, int32_t ay,
 
 	if (!node->is_split) {
 		if (node->client) {
-			struct wlr_box box = {ax, ay, MAX(1, aw), MAX(1, ah)};
-			resize(node->client, box, 0);
+			if (!node->client->isfullscreen &&
+				!node->client->ismaximizescreen) {
+				struct wlr_box box = {ax, ay, MAX(1, aw), MAX(1, ah)};
+				resize(node->client, box, 0);
+			}
 		}
 		return;
 	}
@@ -589,8 +592,13 @@ void dwindle(Monitor *m) {
 					found = true;
 					break;
 				}
-			if (!found)
+			if (!found) {
+				if (VISIBLEON(leaves[i]->client, m) &&
+					(leaves[i]->client->isfullscreen ||
+					 leaves[i]->client->ismaximizescreen))
+					continue;
 				dwindle_remove(root, leaves[i]->client);
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently when toggling a window into fullscreen they are marked as not tiled and therefore removed from the binary tree making it so whenever they are toggled as not fullscreen they are not inserted in the correct branch:

https://github.com/user-attachments/assets/25ae6193-6e17-4c34-a875-b2b1c6d88a8f

To fix this avoid removing the window from the binary tree if it is still visible on the current workspace and  skip resizing it to a tiled container while it is in a fullscreen state:


https://github.com/user-attachments/assets/7cbe7bde-5cb1-417a-82d8-2da49b230788

