### PR TITLE
fix: use uint32_t instead of u_int32_t for musl libc compatibility

### DIFF
--- a/src/mango.c
+++ b/src/mango.c
@@ -468,7 +468,7 @@ typedef struct {
 	struct wl_listener key;
 	struct wl_listener destroy;
 
-	u_int32_t layout_index;
+	uint32_t layout_index;
 } KeyboardGroup;
 
 typedef struct {


### PR DESCRIPTION
Fixes build on musl libc-based systems. Replaces BSD type u_int32_t with POSIX-compliant uint32_t from <stdint.h>