### PR TITLE
guix: fix cjson import module

### DIFF
--- a/mangowm.scm
+++ b/mangowm.scm
@@ -10,7 +10,7 @@
   #:use-module (gnu packages pciutils)
   #:use-module (gnu packages admin)
   #:use-module (gnu packages pcre)
-  #:use-module (gnu packages cjson)
+  #:use-module (gnu packages javascript)
   #:use-module (gnu packages xorg)
   #:use-module (gnu packages build-tools)
   #:use-module (gnu packages ninja)


### PR DESCRIPTION
Currently pulling new commits will fail to build guix due to wrong `#:import-module`.