### PR TITLE
fix: keep window shadow attached during move animations

### DIFF
--- a/src/animation/client.h
+++ b/src/animation/client.h
@@ -363,6 +363,8 @@ void client_draw_shadow(Client *c) {
 	int32_t right_offset, bottom_offset, left_offset, top_offset;
 
 	if (c == grabc) {
+		// Interactive move: the window (and its shadow) genuinely follow the
+		// cursor, possibly across monitors, so never clamp.
 		right_offset = 0;
 		bottom_offset = 0;
 		left_offset = 0;
@@ -377,6 +379,46 @@ void client_draw_shadow(Client *c) {
 
 		left_offset = GEZERO(c->mon->m.x - absolute_shadow_box.x);
 		top_offset = GEZERO(c->mon->m.y - absolute_shadow_box.y);
+
+		// While the window is animating (tag switch, scroller focus scroll,
+		// generic move) it legitimately slides past its monitor edge. Clamping
+		// the shadow to the monitor bounds then pins the shadow's leading edge
+		// to the screen border, so it lags behind the moving window. Only keep
+		// the clamp on edges that actually border another monitor (to stop the
+		// shadow bleeding onto it); release it on free edges so the shadow
+		// travels with the window. The clamp is fully active again at rest.
+		if (c->animation.running) {
+			struct wlr_box *me = &c->mon->m;
+			bool nb_right = false, nb_left = false, nb_below = false,
+				 nb_above = false;
+			Monitor *om;
+			wl_list_for_each(om, &mons, link) {
+				if (om == c->mon || !om->wlr_output ||
+					!om->wlr_output->enabled)
+					continue;
+				struct wlr_box *o = &om->m;
+				bool voverlap =
+					o->y < me->y + me->height && o->y + o->height > me->y;
+				bool hoverlap =
+					o->x < me->x + me->width && o->x + o->width > me->x;
+				if (voverlap && o->x >= me->x + me->width)
+					nb_right = true;
+				if (voverlap && o->x + o->width <= me->x)
+					nb_left = true;
+				if (hoverlap && o->y >= me->y + me->height)
+					nb_below = true;
+				if (hoverlap && o->y + o->height <= me->y)
+					nb_above = true;
+			}
+			if (!nb_right)
+				right_offset = 0;
+			if (!nb_left)
+				left_offset = 0;
+			if (!nb_below)
+				bottom_offset = 0;
+			if (!nb_above)
+				top_offset = 0;
+		}
 	}
 
 	left_offset = MIN(left_offset, shadow_box.width);


### PR DESCRIPTION
## Problem

With shadows enabled, a window's shadow does not move with the window while the window is animating off/across the monitor:

- **Tag switch:** when switching tags, the outgoing (or incoming) window slides off-screen, but its shadow stays pinned at the monitor edge and only catches up once the window has fully moved out.
- **Scroller layout:** when changing focus, windows scroll horizontally and their shadows lag behind in the same way.

## Root cause

`client_draw_shadow()` clamps the shadow box to the monitor bounds so a window's shadow does not bleed onto adjacent monitors. That clamp is correct for a window at rest near a monitor edge, but it also fires while a window is *animating* past the edge. The clamp grows the leading-edge offset every frame, which pins the shadow's leading edge to the screen border while the window keeps moving — so the shadow appears to lag.

The interactive-move case (`c == grabc`) was already exempted from the clamp; animated moves were not.

## Fix

Skip the monitor-edge clamp whenever the client is animating (`c->animation.running`) in addition to the existing drag exemption (`c == grabc`). `animation.running` is set for every animated move (tag switch, scroller focus scroll, generic move) and is cleared when the animation finishes, so the clamp still applies once the window comes to rest near a real monitor edge — preserving the original anti-bleed behaviour.

```c
if (c == grabc || c->animation.running) {
    right_offset = 0;
    bottom_offset = 0;
    left_offset = 0;
    top_offset = 0;
} else {
    /* existing monitor-edge clamp */
}
```

One-line change to the condition (plus an explanatory comment).

## Testing

Built and run with shadows enabled. Verified the shadow now stays attached to the window throughout:

- tag switches in both directions (horizontal tag animation), and
- focus changes in the scroller layout.

Confirmed the shadow is still clamped to the monitor edge for a static window near the screen border (no bleed onto adjacent monitors).
