### PR TITLE
feat: add smartkillclient dispatcher

### DIFF
--- a/docs/bindings/keys.md
+++ b/docs/bindings/keys.md
@@ -89,6 +89,7 @@ bindr=Super,Super_L,spawn,rofi -show run
 | Command | Param | Description |
 | :--- | :--- | :--- |
 | `killclient` | `force` | Close the focused window. If `force` is specified, sends `SIGKILL`. |
+| `smartkillclient` | - | Remove the focused window from the current tag(s) if it is on multiple tags; otherwise close it. |
 | `togglefloating` | - | Toggle floating state. |
 | `toggle_all_floating` | - | Toggle all visible clients floating state. |
 | `togglefullscreen` | - | Toggle fullscreen. |

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -1115,6 +1115,8 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 	} else if (strcmp(func_name, "killclient") == 0) {
 		func = killclient;
 		(*arg).i = parse_force(arg_value);
+	} else if (strcmp(func_name, "smartkillclient") == 0) {
+		func = smartkillclient;
 	} else if (strcmp(func_name, "centerwin") == 0) {
 		func = centerwin;
 	} else if (strcmp(func_name, "focuslast") == 0) {

--- a/src/dispatch/bind_declare.h
+++ b/src/dispatch/bind_declare.h
@@ -37,6 +37,7 @@ void moveresize(const Arg *arg);
 void exchange_client(const Arg *arg);
 void exchange_stack_client(const Arg *arg);
 void killclient(const Arg *arg);
+void smartkillclient(const Arg *arg);
 void toggleglobal(const Arg *arg);
 void incnmaster(const Arg *arg);
 void focusmon(const Arg *arg);

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -512,6 +512,8 @@ void smartkillclient(const Arg *arg) {
 		return;
 
 	uint32_t newtags = c->tags & ~(c->mon->tagset[c->mon->seltags] & TAGMASK);
+	// Kill the client if it's single-tag, or if removing the tag(s) would leave
+	// it on none
 	if (__builtin_popcount(c->tags & TAGMASK) <= 1 || !newtags) {
 		pending_kill_client(c);
 		return;

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -506,6 +506,26 @@ void killclient(const Arg *arg) {
 	return;
 }
 
+void smartkillclient(const Arg *arg) {
+	Client *c = arg->tc ? arg->tc : (selmon ? selmon->sel : NULL);
+	if (!c)
+		return;
+
+	uint32_t newtags = c->tags & ~(c->mon->tagset[c->mon->seltags] & TAGMASK);
+	if (__builtin_popcount(c->tags & TAGMASK) <= 1 || !newtags) {
+		pending_kill_client(c);
+		return;
+	}
+
+	// Remove the client from the currently viewed tag(s) on its own monitor
+	// (the one that changed) while keeping focus on the user's active monitor.
+	c->tags = newtags;
+	focusclient(focustop(selmon), 1);
+	arrange(c->mon, false, false);
+	printstatus(IPC_WATCH_ARRANGGE);
+	return;
+}
+
 void moveresize(const Arg *arg) {
 	const char *cursors[] = {"nw-resize", "ne-resize", "sw-resize",
 							 "se-resize"};


### PR DESCRIPTION
## Summary

Adds a new `smartkillclient` dispatch function: a "smart close" variant of `killclient`.

- If the focused client lives on more than one tag, it is removed from the currently viewed tag(s) instead of being closed.
- If the client is on a single tag (or removing the viewed tag(s) would leave it on none), it falls back to the normal `killclient` behaviour and closes the window.

`killclient` itself is unchanged, so existing configs keep their current behaviour. Users opt in by binding the new function, e.g.:

```
bind=ALT,q,smartkillclient
```

## Motivation

It's common to keep a window on several tags and want a single keybind that "removes it from where I'm looking" when it's multi-tagged, but actually closes it when it isn't. This was previously only doable with an external script driving `mmsg get focusing-client` + `mmsg dispatch toggletag`. This brings the behaviour natively into the compositor.

## Implementation notes

- New function in `src/dispatch/bind_define.h`, declaration in `src/dispatch/bind_declare.h`, and registration in `src/config/parse_config.h` (mirroring `killclient`).
- The "remove from view" branch reuses the same primitives as `toggletag`: set `c->tags`, `focusclient(focustop(selmon), 1)`, `arrange(...)`, `printstatus(IPC_WATCH_ARRANGGE)`.
- The viewed tags are taken from the client's own monitor (`c->mon->tagset[c->mon->seltags]`) and that monitor is re-arranged, while focus is restored on the active monitor (`selmon`) — this keeps the cross-monitor IPC path (`arg->tc`) correct.
- Behavioural note for review: when multiple tags are being viewed at once, this removes the client from all currently-viewed tags, not just one. In the common single-view case this is identical to removing "the current tag". Happy to change it to a single-tag semantic if you'd prefer.

## Testing

- Builds cleanly (`ninja -C build`).
- Manually verified: multi-tagged focused window is removed from the current tag and remaining windows reflow; single-tagged window is closed as before (tested on Asahi Fedora, aarch64).

## Docs

- Added a `smartkillclient` row to `docs/bindings/keys.md`.

---

_Disclaimer: this PR was prepared with the help of AI tools, and I have verified the output._
