### PR TITLE
Nixos: Add autostart script if systemd integration is enabled

### DIFF
--- a/nix/hm-modules.nix
+++ b/nix/hm-modules.nix
@@ -233,7 +233,7 @@ in
             )
         )
         + lib.optionalString (cfg.extraConfig != "") cfg.extraConfig
-        + lib.optionalString (addAutostartScript) "\nexec-once=~/.config/mango/autostart.sh\n";
+        + lib.optionalString addAutostartScript "\nexec-once=~/.config/mango/autostart.sh\n";
 
       validatedConfig = pkgs.runCommand "mango-config.conf" { } ''
         cp ${pkgs.writeText "mango-config.conf" finalConfigText} "$out"
@@ -252,7 +252,7 @@ in
       home.packages = [ cfg.package ];
       xdg.configFile = {
         "mango/config.conf" =
-          lib.mkIf (cfg.settings != { } || cfg.extraConfig != "" || cfg.autostart_sh != "")
+          lib.mkIf (cfg.settings != { } || cfg.extraConfig != "" || addAutostartScript)
             {
               source = validatedConfig;
             };

--- a/nix/hm-modules.nix
+++ b/nix/hm-modules.nix
@@ -11,10 +11,15 @@ let
   variables = lib.concatStringsSep " " cfg.systemd.variables;
   extraCommands = lib.concatStringsSep " && " cfg.systemd.extraCommands;
   systemdActivation = "${pkgs.dbus}/bin/dbus-update-activation-environment --systemd ${variables}; ${extraCommands}";
-  autostart_sh = pkgs.writeShellScript "autostart.sh" ''
-    ${lib.optionalString cfg.systemd.enable systemdActivation}
-    ${cfg.autostart_sh}
-  '';
+  addAutostartScript = cfg.autostart_sh != "" || cfg.systemd.enable;
+  autostart_sh =
+    if addAutostartScript then
+      pkgs.writeShellScript "autostart.sh" ''
+        ${lib.optionalString cfg.systemd.enable systemdActivation}
+        ${cfg.autostart_sh}
+      ''
+    else
+      null;
 in
 {
   options = {
@@ -228,7 +233,7 @@ in
             )
         )
         + lib.optionalString (cfg.extraConfig != "") cfg.extraConfig
-        + lib.optionalString (cfg.autostart_sh != "") "\nexec-once=~/.config/mango/autostart.sh\n";
+        + lib.optionalString (addAutostartScript) "\nexec-once=~/.config/mango/autostart.sh\n";
 
       validatedConfig = pkgs.runCommand "mango-config.conf" { } ''
         cp ${pkgs.writeText "mango-config.conf" finalConfigText} "$out"
@@ -251,7 +256,7 @@ in
             {
               source = validatedConfig;
             };
-        "mango/autostart.sh" = lib.mkIf (cfg.autostart_sh != "") {
+        "mango/autostart.sh" = lib.mkIf addAutostartScript {
           source = autostart_sh;
           executable = true;
         };


### PR DESCRIPTION
Shell script is now only generated when necessary + systemd integration enables execution of autostart script