### PR TITLE
fix: dirty the blur buffer during and after animation/resize

### DIFF
--- a/src/animation/client.h
+++ b/src/animation/client.h
@@ -1243,6 +1243,10 @@ void resize(Client *c, struct wlr_box geo, int32_t interact) {
 	if (!c->mon)
 		return;
 
+	if (config.blur && c->mon->blur) {
+		wlr_scene_optimized_blur_mark_dirty(c->mon->blur);
+	}
+
 	c->need_output_flush = true;
 	c->dirty = true;
 

--- a/src/mango.c
+++ b/src/mango.c
@@ -5045,6 +5045,7 @@ void rendermon(struct wl_listener *listener, void *data) {
 	bool frame_allow_tearing = false;
 	struct timespec now;
 	bool need_more_frames = false;
+	bool need_blur_dirty = false;  // dirty the blur buffer
 
 	if (session && !session->active) {
 		return;
@@ -5060,20 +5061,24 @@ void rendermon(struct wl_listener *listener, void *data) {
 		layer_list = &m->layers[i];
 		wl_list_for_each_safe(l, tmpl, layer_list, link) {
 			need_more_frames = layer_draw_frame(l) || need_more_frames;
+			if (l->animation.running) need_blur_dirty = true;
 		}
 	}
 
 	wl_list_for_each_safe(c, tmp, &fadeout_clients, fadeout_link) {
 		need_more_frames = client_draw_fadeout_frame(c) || need_more_frames;
+		if (l->animation.running) need_blur_dirty = true;
 	}
 
 	wl_list_for_each_safe(l, tmpl, &fadeout_layers, fadeout_link) {
 		need_more_frames = layer_draw_fadeout_frame(l) || need_more_frames;
+		if (l->animation.running) need_blur_dirty = true;
 	}
 
 	// 绘制客户端
 	wl_list_for_each(c, &clients, link) {
 		need_more_frames = client_draw_frame(c) || need_more_frames;
+		if (l->animation.running) need_blur_dirty = true;
 		if (!config.animations && !grabc && c->configure_serial &&
 			client_is_rendered_on_mon(c, m)) {
 			monitor_check_skip_frame_timeout(m);
@@ -5083,6 +5088,10 @@ void rendermon(struct wl_listener *listener, void *data) {
 
 	if (m->skiping_frame) {
 		monitor_stop_skip_frame_timer(m);
+	}
+
+	if (config.blur && m->blur && (need_blur_dirty || need_more_frames)) {
+		wlr_scene_optimized_blur_mark_dirty(m->blur);
 	}
 
 	// 只有在需要帧时才构建和提交状态


### PR DESCRIPTION
Fixes issue #560
On my machine (integrated graphics: AMD Ryzen 5 7640U w/ Radeon 760M Graphics), I have rendering artifacts when two blurred surfaces pass over each other.
`scenefx` does not automatically dirty the blur buffer for you (see https://github.com/wlrfx/scenefx/issues/94), so it is currently the job of the compositor to do so.

This commit manually marks the blur buffer as dirty during client resizing and animation, fixing the artifact issue on my end.

I added a new flag `need_blur_dirty` in `rendermon` that marks the blur buffer as dirty is an animation is playing. I could have used `need_more_frames` as well, but then the last frame would not dirty the buffer, when it should.

Open questions:
- why these artifacts only seem to happen on some machines. Not many people seem to have the same issue, from what I can tell? Maybe they simply don't use a lot of blur?
- is this the best way of implementing this?

Open to any feedback - this is my first PR here