### PR TITLE
feat: differentiate between switch types in switch bindings

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -145,7 +145,10 @@ typedef struct {
 } AxisBinding;
 
 typedef struct {
-	uint32_t fold;
+	struct {
+		enum wlr_switch_type type;
+		enum wlr_switch_state state;
+	} switch_action;
 	int32_t (*func)(const Arg *);
 	Arg arg;
 } SwitchBinding;
@@ -583,24 +586,41 @@ int32_t parse_force(const char *str) {
 	}
 }
 
-int32_t parse_fold_state(const char *str) {
+typeof((SwitchBinding){}.switch_action) parse_switch_action(const char *str) {
 	// 将输入字符串转换为小写
-	char lowerStr[10];
+	char lowerStr[18];
 	int32_t i = 0;
-	while (str[i] && i < 9) {
+	while (str[i] && i < 17) {
 		lowerStr[i] = tolower(str[i]);
 		i++;
 	}
 	lowerStr[i] = '\0';
 
 	// 根据转换后的小写字符串返回对应的枚举值
+	typeof((SwitchBinding){}.switch_action) result = {};
 	if (strcmp(lowerStr, "fold") == 0) {
-		return FOLD;
+		result.type = WLR_SWITCH_TYPE_LID;
+		result.state = WLR_SWITCH_STATE_ON;
 	} else if (strcmp(lowerStr, "unfold") == 0) {
-		return UNFOLD;
+		result.type = WLR_SWITCH_TYPE_LID;
+		result.state = WLR_SWITCH_STATE_OFF;
+	} else if (strcmp(lowerStr, "tablet_on") == 0) {
+		result.type = WLR_SWITCH_TYPE_TABLET_MODE;
+		result.state = WLR_SWITCH_STATE_ON;
+	} else if (strcmp(lowerStr, "tablet_off") == 0) {
+		result.type = WLR_SWITCH_TYPE_TABLET_MODE;
+		result.state = WLR_SWITCH_STATE_OFF;
+	} else if (strcmp(lowerStr, "keypad_slide_on") == 0) {
+		result.type = WLR_SWITCH_TYPE_KEYPAD_SLIDE;
+		result.state = WLR_SWITCH_STATE_ON;
+	} else if (strcmp(lowerStr, "keypad_slide_off") == 0) {
+		result.type = WLR_SWITCH_TYPE_KEYPAD_SLIDE;
+		result.state = WLR_SWITCH_STATE_OFF;
 	} else {
-		return INVALIDFOLD;
+		result.type = -1;
+		result.state = -1;
 	}
+	return result;
 }
 int64_t parse_color(const char *hex_str) {
 	char *endptr;
@@ -2740,7 +2760,7 @@ bool parse_option(Config *config, char *key, char *value) {
 		trim_whitespace(arg_value4);
 		trim_whitespace(arg_value5);
 
-		binding->fold = parse_fold_state(fold_str);
+		binding->switch_action = parse_switch_action(fold_str);
 		binding->func =
 			parse_func_name(func_name, &binding->arg, arg_value, arg_value2,
 							arg_value3, arg_value4, arg_value5);

--- a/src/mango.c
+++ b/src/mango.c
@@ -187,7 +187,6 @@ enum {
 #endif
 enum { UP, DOWN, LEFT, RIGHT, UNDIR }; /* smartmovewin */
 enum { NONE, OPEN, MOVE, CLOSE, TAG, FOCUS, OPAFADEIN, OPAFADEOUT, OVERVIEW };
-enum { UNFOLD, FOLD, INVALIDFOLD };
 enum { PREV, NEXT };
 enum { STATE_UNSPECIFIED = 0, STATE_ENABLED, STATE_DISABLED };
 enum { FORCE, UNFORCE };
@@ -3552,7 +3551,8 @@ void switch_toggle(struct wl_listener *listener, void *data) {
 		if (config.switch_bindings_count < 1)
 			break;
 		s = &config.switch_bindings[ji];
-		if (event->switch_state == s->fold && s->func) {
+		if (event->switch_type == s->switch_action.type &&
+			event->switch_state == s->switch_action.state && s->func) {
 			s->func(&s->arg);
 			return;
 		}


### PR DESCRIPTION
Currently all switch types are handled by the same bind, which practically means that on convertible laptops closing the lid and switching to tablet mode invokes the same action.

This pull request adds the option to bind to any WLR switch type separately while retaining backwards compatibility.