### PR TITLE
feat: monocle tab bar toggle

### DIFF
--- a/docs/visuals/theming.md
+++ b/docs/visuals/theming.md
@@ -69,6 +69,7 @@ You can also color-code windows based on their state:
 ### Tab Bar For Monocle Layout
 | Setting | Default | Description |
 | :--- | :--- | :--- |
+| `tab_bar_enable` | `1` | Set to `0` to disable the monocle tab bar. |
 | `tab_bar_height` | `50` | Height of the tab bar for monocle layout. |
 | `tab_bar_decorate_fg_color` | `0xc4939dff` | text color.
 | `tab_bar_decorate_bg_color` | `0x201b14ff` | background color.|

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -332,6 +332,7 @@ typedef struct {
 	uint32_t gappoh;
 	uint32_t gappov;
 	uint32_t borderpx;
+	uint32_t tab_bar_enable;
 	uint32_t tab_bar_height;
 	float scratchpad_width_ratio;
 	float scratchpad_height_ratio;
@@ -1953,6 +1954,8 @@ bool parse_option(Config *config, char *key, char *value) {
 		config->borderpx = atoi(value);
 	} else if (strcmp(key, "tab_bar_height") == 0) {
 		config->tab_bar_height = atoi(value);
+	} else if (strcmp(key, "tab_bar_enable") == 0) {
+		config->tab_bar_enable = atoi(value);
 	} else if (strcmp(key, "rootcolor") == 0) {
 		int64_t color = parse_color(value);
 		if (color == -1) {
@@ -3569,6 +3572,7 @@ void override_config(void) {
 	config.scratchpad_height_ratio =
 		CLAMP_FLOAT(config.scratchpad_height_ratio, 0.1f, 1.0f);
 	config.borderpx = CLAMP_INT(config.borderpx, 0, 200);
+	config.tab_bar_enable = CLAMP_INT(config.tab_bar_enable, 0, 1);
 	config.tab_bar_height = CLAMP_INT(config.tab_bar_height, 5, 500);
 	config.smartgaps = CLAMP_INT(config.smartgaps, 0, 1);
 	config.blur = CLAMP_INT(config.blur, 0, 1);
@@ -3701,6 +3705,7 @@ void set_value_default() {
 	config.idleinhibit_ignore_visible = 0;
 
 	config.borderpx = 4;
+	config.tab_bar_enable = 1;
 	config.tab_bar_height = 50;
 	config.overviewgappi = 5;
 	config.overviewgappo = 30;

--- a/src/layout/horizontal.h
+++ b/src/layout/horizontal.h
@@ -546,7 +546,7 @@ void deck(Monitor *m) {
 }
 
 void monocle(Monitor *m) {
-	Client *c, *fc;
+	Client *c, *fc = NULL;
 	struct wlr_box geom;
 	int32_t cur_gappov = enablegaps ? m->gappov : 0;
 	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;
@@ -570,13 +570,18 @@ void monocle(Monitor *m) {
 		}
 	}
 
-	if (n == 1) {
+	if (n == 1 || !config.tab_bar_enable) {
 		geom.x = m->w.x + cur_gappoh;
 		geom.y = m->w.y + cur_gappov;
 		geom.width = m->w.width - 2 * cur_gappoh;
 		geom.height = m->w.height - 2 * cur_gappov;
-		client_tile_resize(fc, geom, 0);
-		monocle_set_focus(fc, true);
+
+		wl_list_for_each(c, &clients, link) {
+			if (!VISIBLEON(c, m) || !ISFAKETILED(c))
+				continue;
+			client_tile_resize(fc, geom, 0);
+			monocle_set_focus(fc, true);
+		}
 		return;
 	}
 

--- a/src/layout/horizontal.h
+++ b/src/layout/horizontal.h
@@ -579,8 +579,8 @@ void monocle(Monitor *m) {
 		wl_list_for_each(c, &clients, link) {
 			if (!VISIBLEON(c, m) || !ISFAKETILED(c))
 				continue;
-			client_tile_resize(fc, geom, 0);
-			monocle_set_focus(fc, true);
+			client_tile_resize(c, geom, 0);
+			monocle_set_focus(c, c == fc);
 		}
 		return;
 	}


### PR DESCRIPTION
the monocle tab bar introduced for multi-window monocle is always on and has no option to be disabled, the only related knob (tab_bar_height) is clamped to a minimum of 5, so it cannot be turned off through configuration

added a tab_bar_enable boolean (defaults to 1 to preserve current behaviour) 
when set to 0 falls back to classic monocle behaviour

also initialized fc to NULL
it was used uninitialized and if the fstack scan found no match it would  feed garbage to client_tile_resize