### PR TITLE
ipc: expose scroller_proportion in client JSON

### DIFF
--- a/src/ipc/ipc.h
+++ b/src/ipc/ipc.h
@@ -164,6 +164,7 @@ static cJSON *build_client_json(Client *c) {
 	cJSON_AddNumberToObject(obj, "y", c->geom.y);
 	cJSON_AddNumberToObject(obj, "width", c->geom.width);
 	cJSON_AddNumberToObject(obj, "height", c->geom.height);
+	cJSON_AddNumberToObject(obj, "scroller_proportion", (double)c->scroller_proportion);
 	return obj;
 }
 


### PR DESCRIPTION
The scroller layout already maintains per-client proportion values
(like scroller_proportion), but they are not included in the
IPC client JSON response.

This adds the proportion field to build_client_json() so external tools
(e.g. custom scripts) can read the current scroller state.

This is a pure IPC exposure change — no compositor behavior is altered.