### PR TITLE
fix: use output scale for tab bar text rendering on HiDPI displays

### DIFF
--- a/src/action/client.h
+++ b/src/action/client.h
@@ -118,5 +118,5 @@ void client_add_tab_bar_node(Client *c) {
 		mangonodedata, layers[LyrDecorate], config.tabdata, 0, 0);
 	wlr_scene_node_lower_to_bottom(&c->tab_bar_node->scene_buffer->node);
 	wlr_scene_node_set_enabled(&c->tab_bar_node->scene_buffer->node, false);
-	mango_tab_bar_node_update(c->tab_bar_node, client_get_title(c), 1.0);
+	mango_tab_bar_node_update(c->tab_bar_node, client_get_title(c), c->mon ? c->mon->wlr_output->scale : 1.0f);
 }

--- a/src/mango.c
+++ b/src/mango.c
@@ -6736,7 +6736,7 @@ void updatetitle(struct wl_listener *listener, void *data) {
 
 	const char *title;
 	title = client_get_title(c);
-	mango_tab_bar_node_update(c->tab_bar_node, title, 1.0);
+	mango_tab_bar_node_update(c->tab_bar_node, title, c->mon ? c->mon->wlr_output->scale : 1.0f);
 	if (title && c->foreign_toplevel)
 		wlr_foreign_toplevel_handle_v1_set_title(c->foreign_toplevel, title);
 	if (c == focustop(c->mon))


### PR DESCRIPTION
mango_tab_bar_node_update was called with a hardcoded scale of 1.0 in both client_add_tab_bar_node and updatetitle.  On HiDPI outputs the compositor scales the resulting 1x buffer up, producing blurry text.

Pass the client's output scale (wlr_output->scale) instead, falling back to 1.0 when the client has no monitor assigned yet.