### PR TITLE
fix: add missing import to mangowm.scm

### DIFF
--- a/mangowm.scm
+++ b/mangowm.scm
@@ -5,6 +5,7 @@
   #:use-module (guix packages)
   #:use-module (guix utils)
   #:use-module (gnu packages wm)
+  #:use-module (gnu packages gtk)
   #:use-module (gnu packages freedesktop)
   #:use-module (gnu packages xdisorg)
   #:use-module (gnu packages pciutils)


### PR DESCRIPTION
mangowm.scm build was failing due to missing gnu packages gtk import needed for pando. add the import.