### PR TITLE
Enable animation for comboview

### DIFF
--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1657,7 +1657,7 @@ int32_t comboview(const Arg *arg) {
 		arrange(selmon, false, false);
 	} else {
 		tag_combo = true;
-		view(&(Arg){.ui = newtags}, false);
+		view(&(Arg){.ui = newtags}, true);
 	}
 
 	printstatus(IPC_WATCH_ARRANGGE);


### PR DESCRIPTION
When using `comboview`, the initial press is not animated, making it quite jarring compared to using `view`.
I changed the `want_animation` flag to `true` and it seems to work very well. Single presses now animate like `view` and using a combo is also smoother.