### PR TITLE
fix: don't trigger keyrepeat on key release

### DIFF
--- a/src/mango.c
+++ b/src/mango.c
@@ -4420,7 +4420,8 @@ void keypress(struct wl_listener *listener, void *data) {
 		tag_combo = false;
 	}
 
-	if (handled && group->wlr_group->keyboard.repeat_info.delay > 0) {
+	if (handled && group->wlr_group->keyboard.repeat_info.delay > 0 &&
+		event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 		group->mods = mods;
 		group->keysyms = syms;
 		group->keycode = keycode;


### PR DESCRIPTION
when you register a binding for both `bind` and `bindr` for same key combination, releasing a key would leave keyrepeat stuck repeatedly running the `bind` binding until some other key was pressed or released due to the release event re-arming the keyrepeat timer.