### PR TITLE
feat: add load_config_file

### DIFF
--- a/docs/bindings/keys.md
+++ b/docs/bindings/keys.md
@@ -167,6 +167,7 @@ bindr=Super,Super_L,spawn,rofi -show run
 | `spawn_shell` | `cmd` | Execute shell command (supports pipes `\|`). |
 | `spawn_on_empty` | `cmd,tagnumber` | Open command on empty tag. |
 | `reload_config` | - | Hot-reload configuration. |
+| `load_config_file` | `file path` | Load configuration from the specified file. Empty path resets to default config location. |
 | `quit` | - | Exit mangowm. |
 | `toggleoverview` | - | Toggle overview mode. |
 | `togglejump` | - | Toggle overview with jump mode. |

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -1212,6 +1212,9 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 		(*arg).i = atoi(arg_value);
 	} else if (strcmp(func_name, "reload_config") == 0) {
 		func = reload_config;
+	} else if (strcmp(func_name, "load_config_file") == 0) {
+		func = load_config_file;
+		(*arg).v = strdup(arg_value);
 	} else if (strcmp(func_name, "tag") == 0) {
 		func = tag;
 		(*arg).ui = 1 << (atoi(arg_value) - 1);
@@ -3085,7 +3088,7 @@ bool parse_config_file(Config *config, const char *file_path, bool must_exist) {
 	if (file_path[0] == '.' && file_path[1] == '/') {
 		// Relative path
 
-		if (cli_config_path) {
+		if (cli_config_path[0]) {
 			char *config_path = strdup(cli_config_path);
 			char *config_dir = dirname(config_path);
 			snprintf(full_path, sizeof(full_path), "%s/%s", config_dir,
@@ -4007,7 +4010,7 @@ bool parse_config(void) {
 
 	create_config_keymap();
 
-	if (cli_config_path) {
+	if (cli_config_path[0]) {
 		snprintf(filename, sizeof(filename), "%s", cli_config_path);
 	} else {
 		// 获取当前用户家目录

--- a/src/dispatch/bind_declare.h
+++ b/src/dispatch/bind_declare.h
@@ -43,6 +43,7 @@ int32_t focusstack(const Arg *arg);
 int32_t groupfocus(const Arg *arg);
 int32_t chvt(const Arg *arg);
 int32_t reload_config(const Arg *arg);
+int32_t load_config_file(const Arg *arg);
 int32_t smartmovewin(const Arg *arg);
 int32_t smartresizewin(const Arg *arg);
 int32_t centerwin(const Arg *arg);

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -2198,3 +2198,9 @@ int32_t focusid(const Arg *arg) {
 	client_active(c);
 	return 0;
 }
+
+int32_t load_config_file(const Arg *arg) {
+	snprintf(cli_config_path, sizeof(cli_config_path), "%s", arg->v);
+	reload_config(arg);
+	return 0;
+}

--- a/src/mango.c
+++ b/src/mango.c
@@ -1073,7 +1073,7 @@ static struct wl_event_source *hide_cursor_source;
 static struct wl_event_source *keep_idle_inhibit_source;
 static bool cursor_hidden = false;
 static bool tag_combo = false;
-static const char *cli_config_path = NULL;
+static char cli_config_path[1024] = {0};
 static int active_capture_count = 0;
 static bool cli_debug_log = false;
 static KeyMode keymode = {
@@ -7514,7 +7514,7 @@ int32_t main(int32_t argc, char *argv[]) {
 			printf("mango " VERSION "\n");
 			return EXIT_SUCCESS;
 		} else if (c == 'c') {
-			cli_config_path = optarg;
+			snprintf(cli_config_path, sizeof(cli_config_path), "%s", optarg);
 		} else if (c == 'p') {
 			return parse_config() ? EXIT_SUCCESS : EXIT_FAILURE;
 		} else {


### PR DESCRIPTION
Allows to change the config file path at runtime.

Intended for setups that generate/change config files programmatically (e.g. a nix systemd reload hook) where config path isn't known/fixed at launch time. Should also be useful for other scripting purposes.