### PR TITLE
opt: reverse monitorrule apply order

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -4073,10 +4073,7 @@ void reapply_monitor_rules(void) {
 		if (!m->wlr_output->enabled)
 			continue;
 
-		for (ji = 0; ji < config.monitor_rules_count; ji++) {
-			if (config.monitor_rules_count < 1)
-				break;
-
+		for (ji = config.monitor_rules_count - 1; ji >= 0; ji--) {
 			mr = &config.monitor_rules[ji];
 
 			if (monitor_matches_rule(m, mr)) {


### PR DESCRIPTION
Makes the last matching monitorrule be applied instead of the first, allowing to override monitorrules at runtime.

Also removes a redundant monitor_rules_count check.