### PR TITLE
fix: pass un-split remainder as last IPC dispatch token

### DIFF
--- a/src/ipc/ipc.h
+++ b/src/ipc/ipc.h
@@ -390,7 +390,10 @@ static void handle_command(int client_fd, const char *cmd_raw) {
 			while (end >= token && (*end == ' ' || *end == '\t'))
 				*end-- = '\0';
 			tokens[token_count++] = token;
-			token = strtok_r(NULL, ",", &saveptr);
+			if (token_count >= 5)
+				token = saveptr;
+			else
+				token = strtok_r(NULL, ",", &saveptr);
 		}
 
 		Arg arg = {0};


### PR DESCRIPTION
Fixes truncation of IPC dispatches with more than 6 tokens, such as setoption combined with monitorrule, or spawn/spawn_shell.