### PR TITLE
opt: focus selected client on monocle/fullscreen monitors

### DIFF
--- a/src/fetch/client.h
+++ b/src/fetch/client.h
@@ -290,6 +290,12 @@ Client *find_client_by_direction(Client *tc, const Arg *arg,
 
 	if (tempSameMonitorFocusClients)
 		return tempSameMonitorFocusClients;
+	if (tempFocusClients) {
+		Monitor *tm = tempFocusClients->mon;
+		if (tm->sel && (tm->pertag->ltidxs[tm->pertag->curtag]->id == MONOCLE ||
+						tm->sel->isfullscreen))
+			return tm->sel;
+	}
 	return tempFocusClients;
 }
 


### PR DESCRIPTION
When using focusdir with focus_cross_monitor=1, and focusing to a monitor that is monocle or fullscreen, it now focuses the monitors selected client, instead of one that is possibly invisible to the user.