### PR TITLE
fix(nix): stop shadowing builtin removeAttrs in `lib.nix`

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -6,7 +6,6 @@ let
     foldl
     generators
     partition
-    removeAttrs
     ;
 
   inherit (lib.strings)


### PR DESCRIPTION
`nix/lib.nix` inherited `removeAttrs` from `lib`, which is just an alias for `builtins.removeAttrs`. This shadows the Nix builtin and triggers a `sema-primop-overridden` lint warning.

Dropped the unnecessary `inherit`. Call sites now resolve directly to `builtins.removeAttrs`. No behavior change.

Verification:
- `nix build .#mango` **succeeds**, `./result/bin/mango -v` reports `0.14.4(release)`.
- `toMango` output unchanged before/after:
  ```
  nix eval --impure --expr '(import ./nix/lib.nix (import <nixpkgs> {}).lib).toMango {} { blur = 1; bind = ["a" "b"]; }'
  # => "bind = a\nbind = b\nblur = 1\n"
  ```