### PR TITLE
fix: correct get_keyboard_grab judge

### DIFF
--- a/src/ext-protocol/text-input.h
+++ b/src/ext-protocol/text-input.h
@@ -103,11 +103,7 @@ get_keyboard_grab(KeyboardGroup *keyboard) {
 		return NULL;
 	}
 
-	// kb_group是一个物理键盘组，它不应该被过滤掉
-	if (keyboard != kb_group)
-		return NULL;
-
-	if (is_keyboard_emulated_by_input_method(&keyboard->wlr_group->keyboard,
+	if (is_keyboard_emulated_by_input_method(keyboard->virtual_keyboard,
 											 input_method)) {
 		return NULL;
 	}

--- a/src/mango.c
+++ b/src/mango.c
@@ -489,6 +489,7 @@ typedef struct {
 
 typedef struct {
 	struct wlr_keyboard_group *wlr_group;
+	struct wlr_keyboard *virtual_keyboard;
 
 	int32_t nsyms;
 	const xkb_keysym_t *keysyms; /* invalid if nsyms == 0 */
@@ -7268,6 +7269,7 @@ void virtualkeyboard(struct wl_listener *listener, void *data) {
 	wlr_seat_set_capabilities(seat,
 							  seat->capabilities | WL_SEAT_CAPABILITY_KEYBOARD);
 	KeyboardGroup *group = createkeyboardgroup();
+	group->virtual_keyboard = &kb->keyboard;
 	/* Set the keymap to match the group keymap */
 	wlr_keyboard_set_keymap(&kb->keyboard, group->wlr_group->keyboard.keymap);
 	LISTEN(&kb->keyboard.base.events.destroy, &group->destroy,


### PR DESCRIPTION
`is_keyboard_emulated_by_input_method` was being called with `wlr_keyboard_group`'s `wlr_keyboard` causing it to always return false. Also removes a now unneeded `KeyboardGroup` check.

Fixes virtual keyboards not getting grabbed by input method.