### PR TITLE
fix(nix): create autostart.sh in home-manager module when systemd is enabled

### DIFF
--- a/nix/hm-modules.nix
+++ b/nix/hm-modules.nix
@@ -228,7 +228,7 @@ in
             )
         )
         + lib.optionalString (cfg.extraConfig != "") cfg.extraConfig
-        + lib.optionalString (cfg.autostart_sh != "") "\nexec-once=~/.config/mango/autostart.sh\n";
+        + lib.optionalString (autostart_sh != "") "\nexec-once=~/.config/mango/autostart.sh\n";
 
       validatedConfig = pkgs.runCommand "mango-config.conf" { } ''
         cp ${pkgs.writeText "mango-config.conf" finalConfigText} "$out"
@@ -247,11 +247,11 @@ in
       home.packages = [ cfg.package ];
       xdg.configFile = {
         "mango/config.conf" =
-          lib.mkIf (cfg.settings != { } || cfg.extraConfig != "" || cfg.autostart_sh != "")
+          lib.mkIf (cfg.settings != { } || cfg.extraConfig != "" || autostart_sh != "")
             {
               source = validatedConfig;
             };
-        "mango/autostart.sh" = lib.mkIf (cfg.autostart_sh != "") {
+        "mango/autostart.sh" = lib.mkIf (autostart_sh != "") {
           source = autostart_sh;
           executable = true;
         };


### PR DESCRIPTION
`~/.config/mango/autostart.sh` is where systemd gets activated, but autostart.sh would previously only be created if the user specified other commands to go in there. This PR creates autostart.sh even if it only contains the systemd activation.