### PR TITLE
fix: preserve monitor layout in disable_monitor to fix DPMS wake on NVIDIA

### DIFF
--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1943,7 +1943,7 @@ int32_t disable_monitor(const Arg *arg) {
 		if (match_monitor_spec(arg->v, m)) {
 			wlr_output_state_set_enabled(&m->pending, false);
 			mango_output_commit(m);
-			m->only_sleep = 0;
+			m->only_sleep = 1;
 			updatemons(NULL, NULL);
 			break;
 		}


### PR DESCRIPTION
## Problem

Since v0.15.0, `disable_monitor` sets `m->only_sleep = 0`, which causes `updatemons()` to **completely remove the output from the layout** (disconnect it).

On NVIDIA (proprietary driver 610.x, wlroots 0.20), when the monitor is re-enabled via `enable_monitor`, the DRM handshake fails silently and the screen stays black. The only recovery is a TTY switch (Ctrl+Alt+F2 → F1), which forces a full DRM re-init.

This is a **regression from v0.14.x**, where the old `m->asleep` flag was set to `1` in `disable_monitor`, keeping the output in the layout while powered off.

## Root cause

Commit b0326d7 ("feat: distinguish dpms dispatch and disable dispatch in monitor") renamed `asleep` to `only_sleep` and changed the value set by `disable_monitor` from `1` to `0`:

```diff
- m->asleep = 1;    // v0.14.x: output stays in layout, just powered off
+ m->only_sleep = 0; // v0.15.x: output gets removed from layout entirely
```

In `updatemons()`, the check is:
```c
if (m->only_sleep)
    continue;  // skip removing from layout
```

With `only_sleep = 0`, the output is removed from the layout → fully disconnected → NVIDIA can't recover the display on re-enable.

## Fix

Set `only_sleep = 1` in `disable_monitor` so the output stays in the layout while powered off, matching the pre-v0.15 behavior:

```diff
  m->only_sleep = 1;  // keep output in layout, just power off
```

## Testing

- **Before fix**: screen goes black after idle timeout (DMS `acMonitorTimeout`), does not wake on mouse/keyboard input, only recovers via TTY switch
- **After fix**: screen goes black after idle timeout, **wakes correctly** on mouse movement ✅

## Environment
- Mango 0.15.1
- NVIDIA RTX 4050 Mobile (driver 610.43.03)
- wlroots 0.20.2
- CachyOS (Arch Linux), kernel 7.1.3
- DMS Shell 1.5.0 (uses `mmsg dispatch disable_monitor` for idle DPMS)

## Notes

The new `dpms_off_monitor` / `dpms_on_monitor` commands added in commit b0326d7 are not yet available in the released v0.15.1 binary (`mmsg dispatch dpms_off_monitor` returns `unknown function`), so clients like DMS that rely on `disable_monitor` for DPMS need this fix.