### PR TITLE
fix: correct Screenshot portal interface name

### DIFF
--- a/nix/nixos-modules.nix
+++ b/nix/nixos-modules.nix
@@ -39,7 +39,7 @@ in {
           # except those
           "org.freedesktop.impl.portal.Secret" = ["gnome-keyring"];
           "org.freedesktop.impl.portal.ScreenCast" = ["wlr"];
-          "org.freedesktop.impl.portal.ScreenShot" = ["wlr"];
+          "org.freedesktop.impl.portal.Screenshot" = ["wlr"];
 
           # wlr does not have this interface
           "org.freedesktop.impl.portal.Inhibit" = [];


### PR DESCRIPTION
## Problem

The NixOS module's portal config keys the screenshot impl as `org.freedesktop.impl.portal.ScreenShot`, but the real D-Bus interface is `org.freedesktop.impl.portal.Screenshot` (lowercase "s" in "shot").

Because the key never matches the actual interface, `xdg-desktop-portal` never binds Screenshot to the `wlr` backend. It falls through to `default=gtk`, which has no Screenshot implementation, so the frontend drops the interface entirely. Screenshot tools that go through the portal (e.g. flameshot) then report that no portal is available.

`ScreenCast` right above it is spelled correctly, which is why screencast/screen-share works while screenshots don't.

## Fix

Rename the key to the correct interface name so the `wlr` backend handles Screenshot.

## Testing

After rebuild + `systemctl --user restart xdg-desktop-portal`:

```
busctl --user introspect org.freedesktop.portal.Desktop /org/freedesktop/portal/desktop | grep -i screenshot
```

now lists the Screenshot interface (previously empty), and `flameshot gui` works.