### PR TITLE
Translate comments in src/action directory to English

### DIFF
--- a/src/action/client.h
+++ b/src/action/client.h
@@ -1,5 +1,5 @@
 static void client_swap_layout_properties(Client *c1, Client *c2) {
-	// Grid 属性交换
+	// grid property swap
 	double grid_col_per = c1->grid_col_per;
 	double grid_row_per = c1->grid_row_per;
 	int32_t grid_col_idx = c1->grid_col_idx;
@@ -15,7 +15,7 @@ static void client_swap_layout_properties(Client *c1, Client *c2) {
 	c2->grid_col_idx = grid_col_idx;
 	c2->grid_row_idx = grid_row_idx;
 
-	// Master / Stack 属性交换
+	// master / stack property swap
 	double master_inner_per = c1->master_inner_per;
 	double master_mfact_per = c1->master_mfact_per;
 	double stack_inner_per = c1->stack_inner_per;

--- a/src/action/monitor.h
+++ b/src/action/monitor.h
@@ -9,7 +9,7 @@ bool mango_scene_output_commit(struct wlr_scene_output *scene_output,
 	if (!wlr_scene_output_needs_frame(scene_output))
 		return true;
 
-	// 构建状态，将场景的 Buffer 附着到 state 上
+	// build the state, attaching the scene's Buffer to it
 	if (!wlr_scene_output_build_state(scene_output, state, NULL))
 		return false;
 
@@ -19,18 +19,18 @@ bool mango_scene_output_commit(struct wlr_scene_output *scene_output,
 		state->tearing_page_flip = false;
 	}
 
-	// 测试是否支持撕裂
+	// test whether tearing is supported
 	if (state->tearing_page_flip == true) {
 		if (!wlr_output_test_state(wlr_output, state)) {
-			// 如果 DRM 拒绝（例如当前输出/驱动不支持撕裂），降级关闭撕裂
+			// if DRM rejects (e.g. the current output/driver doesn't support tearing), fall back to disabling tearing
 			state->tearing_page_flip = false;
 		}
 	}
 
-	// 提交状态
+	// commit state
 	committed = wlr_output_commit_state(wlr_output, state);
 	if (!committed && state->tearing_page_flip) {
-		// 重试一次
+		// retry once
 		state->tearing_page_flip = false;
 		committed = wlr_output_commit_state(wlr_output, state);
 	}


### PR DESCRIPTION
In this pull request, I translated all comments in the files under the `src/action` directory to English, leaving the actual code completely unchanged.