### PR TITLE
fix(guix): update dependencies

### DIFF
--- a/mangowm.scm
+++ b/mangowm.scm
@@ -4,7 +4,7 @@
   #:use-module (guix gexp)
   #:use-module (guix packages)
   #:use-module (guix utils)
-  #:use-module (gnu packages wm)
+  #:use-module (gnu packages window-management)
   #:use-module (gnu packages gtk)
   #:use-module (gnu packages freedesktop)
   #:use-module (gnu packages xdisorg)
@@ -60,8 +60,8 @@
                   libxcb
                   pixman
                   xcb-util-wm
-                  wlroots-0.19
-                  scenefx))
+                  wlroots-0.20
+                  scenefx-0.5))
     (native-inputs (list pkg-config wayland-protocols))
     (home-page "https://github.com/mangowm/mango")
     (synopsis "Wayland compositor based on wlroots and scenefx")
@@ -71,6 +71,23 @@ built on dwl — crafted for speed, flexibility, and a customizable desktop expe
     (license (list license:gpl3 ;mangowm itself, dwl
                    license:expat ;dwm, sway, wlroots
                    license:cc0)))) ;tinywl
+
+(define-public scenefx-0.5
+  (package
+    (inherit scenefx)
+    (name "scenefx")
+    (version "0.5")
+    (source (origin
+              (method git-fetch)
+              (uri (git-reference
+                     (url "https://github.com/wlrfx/scenefx")
+                     (commit version)))
+              (file-name (git-file-name name version))
+              (sha256
+               (base32
+                "0klxy73125lp9jab8qghh4v6di91l3y2rgan4m4lhv5flwdwnj5x"))))
+    (inputs (modify-inputs (package-inputs scenefx)
+              (replace "wlroots" wlroots-0.20)))))
 
 (define-deprecated-package mangowc
   mangowm-git)


### PR DESCRIPTION
This updates wlroots to 0.20 and scenefx to 0.5 in guix package.

scenefx-0.5 is not yet packaged in Guix. I've added a temporary small inline definition that inherits from the existing scenefx (version 0.4) package. I'm currently working on packaging it properly on Guix.

Also updated `(gnu packages wm)` to `(gnu packages window-management)` in use-modules since Guix recently renamed that module. It still works due to backward compatibility, but is subject to be removed in the future.

I haven't tested it deeply, but it seems to be fully working:
<img width="1362" height="334" alt="image" src="https://github.com/user-attachments/assets/138394f8-7661-464e-b7c5-c290f937a931" />
<img width="1470" height="909" alt="image" src="https://github.com/user-attachments/assets/97568632-0e00-4706-b510-3070edd61b2a" />

