### PR TITLE
Fix stale drop preview and layout hole from interrupted drags

### DIFF
--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1443,7 +1443,7 @@ int32_t togglefakefullscreen(const Arg *arg) {
 }
 
 int32_t togglefloating(const Arg *arg) {
-	if (!selmon)
+	if (!selmon || grabc)
 		return 0;
 
 	Client *sel = arg->tc ? arg->tc : focustop(selmon);

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1834,7 +1834,7 @@ void fix_mon_tagset_from_overview(Monitor *m) {
 
 int32_t toggleoverview(const Arg *arg) {
 	Client *c = NULL;
-	if (!selmon)
+	if (!selmon || grabc)
 		return 0;
 
 	Client *sel = arg->tc ? arg->tc : selmon->sel;

--- a/src/mango.c
+++ b/src/mango.c
@@ -4929,7 +4929,7 @@ void unminimize(Client *c) {
 
 void set_minimized(Client *c) {
 
-	if (!c || !c->mon)
+	if (!c || !c->mon || c == grabc)
 		return;
 
 	c->isglobal = 0;
@@ -5847,7 +5847,8 @@ void exit_scroller_stack(Client *c) {
 
 void setmaximizescreen(Client *c, int32_t maximizescreen, bool rearrange) {
 	struct wlr_box maximizescreen_box;
-	if (!c || !c->mon || !client_surface(c)->mapped || c->iskilling)
+	if (!c || !c->mon || !client_surface(c)->mapped || c->iskilling ||
+		c == grabc)
 		return;
 
 	if (c->mon->isoverview)
@@ -5910,7 +5911,8 @@ void setfullscreen(Client *c, int32_t fullscreen,
 				   bool rearrange) // 用自定义全屏代理自带全屏
 {
 
-	if (!c || !c->mon || !client_surface(c)->mapped || c->iskilling)
+	if (!c || !c->mon || !client_surface(c)->mapped || c->iskilling ||
+		c == grabc)
 		return;
 
 	if (c->mon->isoverview)

--- a/src/mango.c
+++ b/src/mango.c
@@ -6903,6 +6903,11 @@ void unmapnotify(struct wl_listener *listener, void *data) {
 	if (c == grabc) {
 		cursor_mode = CurNormal;
 		grabc = NULL;
+		if (dropc) {
+			dropc->enable_drop_area_draw = false;
+			client_set_drop_area(dropc);
+			dropc = NULL;
+		}
 	}
 
 	if (c == dropc) {


### PR DESCRIPTION
Two cleanup bugs when an interactive drag (`drag_tile_to_tile=1`) is interrupted instead of finishing with a normal drop:

**1. Drop preview stays visible if the dragged window is closed mid-drag**

The drop-area rect lives on the *target* client (`dropc`). Button release disables it, but `unmapnotify` only reset `grabc`/`cursor_mode` when the dragged client died, leaving `dropc->enable_drop_area_draw` set — the preview stayed painted on the target window until the next arrange. Now the `c == grabc` branch does the same drop-area cleanup as button release.

**Repro:** drag a tiled window over another so the preview shows, close it mid-drag (e.g. the app exits) → preview rect remains.

**2. `togglefloating` during a drag corrupts the layout (empty slot)**

`togglefloating` had no guard against an active drag. Dragging a tiled window temporarily floats it; pressing the togglefloating bind mid-drag set it back to `isfloating=0` while it still followed the cursor, so arrange re-inserted it into the layout (dwindle allocates a leaf) while its geometry stayed under the cursor — an empty slot. On release `place_drag_tile_client` inserted it a second time, leaving a persistent hole until the tree is rebuilt. Now `togglefloating` is a no-op while `grabc` is set, same as the existing guard in `toggle_hotarea`.

**Repro:** dwindle layout, Super+drag a tiled window, press the togglefloating bind while still dragging, release → empty space where the window's slot was.

Built and running on 0.15.4 (Void Linux, wlroots 0.20.2 / scenefx 0.5); will confirm both repros after further daily use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**3. Other client-state changes during a drag**

Same class of bug as #2: fullscreening the grabbed window mid-drag (bind, IPC, or the app requesting it) reparents/resizes it while the interactive move still owns its geometry, with similarly broken results — likewise maximize, minimize, and entering overview. Guarded the setters (`setfullscreen`, `setmaximizescreen`, `set_minimized`) against `c == grabc`, and made `toggleoverview` a no-op while a drag is active. End-of-drag paths clear `grabc` before re-placing the client, so normal drops are unaffected.
