### PR TITLE
fix: clean up interrupted interactive drags (stale drop preview, layout hole)

### DIFF
--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1443,7 +1443,7 @@ int32_t togglefakefullscreen(const Arg *arg) {
 }
 
 int32_t togglefloating(const Arg *arg) {
-	if (!selmon)
+	if (!selmon || grabc)
 		return 0;
 
 	Client *sel = arg->tc ? arg->tc : focustop(selmon);

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1834,7 +1834,7 @@ void fix_mon_tagset_from_overview(Monitor *m) {
 
 int32_t toggleoverview(const Arg *arg) {
 	Client *c = NULL;
-	if (!selmon)
+	if (!selmon || grabc)
 		return 0;
 
 	Client *sel = arg->tc ? arg->tc : selmon->sel;

--- a/src/mango.c
+++ b/src/mango.c
@@ -4929,7 +4929,7 @@ void unminimize(Client *c) {
 
 void set_minimized(Client *c) {
 
-	if (!c || !c->mon)
+	if (!c || !c->mon || c == grabc)
 		return;
 
 	c->isglobal = 0;
@@ -5847,7 +5847,8 @@ void exit_scroller_stack(Client *c) {
 
 void setmaximizescreen(Client *c, int32_t maximizescreen, bool rearrange) {
 	struct wlr_box maximizescreen_box;
-	if (!c || !c->mon || !client_surface(c)->mapped || c->iskilling)
+	if (!c || !c->mon || !client_surface(c)->mapped || c->iskilling ||
+		c == grabc)
 		return;
 
 	if (c->mon->isoverview)
@@ -5910,7 +5911,8 @@ void setfullscreen(Client *c, int32_t fullscreen,
 				   bool rearrange) // 用自定义全屏代理自带全屏
 {
 
-	if (!c || !c->mon || !client_surface(c)->mapped || c->iskilling)
+	if (!c || !c->mon || !client_surface(c)->mapped || c->iskilling ||
+		c == grabc)
 		return;
 
 	if (c->mon->isoverview)

--- a/src/mango.c
+++ b/src/mango.c
@@ -6903,6 +6903,11 @@ void unmapnotify(struct wl_listener *listener, void *data) {
 	if (c == grabc) {
 		cursor_mode = CurNormal;
 		grabc = NULL;
+		if (dropc) {
+			dropc->enable_drop_area_draw = false;
+			client_set_drop_area(dropc);
+			dropc = NULL;
+		}
 	}
 
 	if (c == dropc) {


### PR DESCRIPTION
## Problem

When an interactive move with `drag_tile_to_tile=1` gets interrupted instead of ending with a normal drop, mango is left in a bad state. Three cases:

1. **Closing the dragged window mid-drag leaves the drop preview visible.** The dropcolor rect lives on the *target* client (`dropc`). Button release disables it, but if the dragged window unmaps first, it stays painted on the target window until the next arrange.

2. **Pressing togglefloating mid-drag corrupts the layout.** Dragging a tiled window temporarily floats it; togglefloating flips it back to `isfloating=0` while it still follows the cursor, so arrange re-inserts it into the layout (dwindle allocates a leaf) with nothing rendered there. On release `place_drag_tile_client` inserts it a second time → duplicate leaf and a persistent empty slot until the tree gets rebuilt.

3. **Fullscreen/maximize/minimize/overview mid-drag do something similar** — the state change runs on the grabbed client while the drag still owns its geometry.

Repro for 2 (dwindle layout): spawn two terminals, super+drag one, hit your togglefloating bind while still holding, release → empty space where its slot was.

## Fix

- `unmapnotify`: when the dying client is `grabc`, also clear the drop area on `dropc` (same cleanup button release already does).
- `togglefloating`: no-op while a drag is active (same guard `toggle_hotarea` already uses).
- `setfullscreen` / `setmaximizescreen` / `set_minimized`: ignore `c == grabc`, which covers keybinds, IPC and clients requesting fullscreen themselves. `toggleoverview`: no-op during a drag (drags already can't *start* in overview).

All end-of-drag paths clear `grabc` before re-placing the client, so normal drops are unaffected.

Tested on 0.15.4, Void Linux, wlroots 0.20.2 / scenefx 0.5.
