### PR TITLE
fix: drop dragged window onto the current tag after switching view mid-drag

### DIFF
--- a/src/mango.c
+++ b/src/mango.c
@@ -2540,6 +2540,10 @@ bool handle_buttonpress(struct wlr_pointer_button_event *event) {
 			selmon = xytomon(cursor->x, cursor->y);
 			client_update_oldmonname_record(grabc, selmon);
 			setmon(grabc, selmon, 0, true);
+			/* if the view changed mid-drag, drop onto the current tag
+			 * instead of silently returning to the original one */
+			if (!VISIBLEON(grabc, selmon))
+				grabc->tags = selmon->tagset[selmon->seltags];
 			selmon->prevsel = ISTILED(selmon->sel) ? selmon->sel : NULL;
 			selmon->sel = grabc;
 			tmpc = grabc;


### PR DESCRIPTION
Fixes #1184

When you drag a window and switch to another tag with a keybinding, the drop preview is shown on the new tag's windows, but on release the window silently stays on its original tag (and vanishes from the current view). Cause: `c->tags` is never updated on drop — `setmon` early-returns when the monitor didn't change, so only cross-*monitor* drops ever retag.

This makes the drop follow the view: on release, if the grabbed window isn't visible on the current tagset, it gets retagged to it, so it lands where you dropped it — matching what the drop preview already promises. Global/sticky windows are unaffected (the check goes through `VISIBLEON`).

Tested on 0.15.4, Void Linux, wlroots 0.20.2 / scenefx 0.5: drag + view switch + drop now moves the window to the new tag and tiles it at the previewed position; normal same-tag drags behave as before.

This would also make sense as a config option if you'd rather keep the old behavior available, but since the preview is already shown on the target tag, following it seems like the expected default.
