### PR TITLE
fix: dragged window hidden after switching tag mid-drag

### DIFF
--- a/src/layout/arrange.h
+++ b/src/layout/arrange.h
@@ -1204,7 +1204,8 @@ void pre_caculate_before_arrange(Monitor *m, bool want_animation,
 				if (!only_caculate)
 					set_arrange_visible(m, c, want_animation);
 			} else {
-				if (!only_caculate)
+				/* keep the dragged client visible across view switches */
+				if (!only_caculate && c != grabc)
 					set_arrange_hidden(m, c, want_animation);
 			}
 		}


### PR DESCRIPTION
Follow-up to #1184 ([comment](https://github.com/mangowm/mango/issues/1184#issuecomment-5020241345)): dragging a window to an empty tag shows no drag_tile_small preview, the window just vanishes until you drop it.

## Cause
The grabbed client keeps its old tags mid-drag, so arrange() puts it in the hidden branch on a view switch. It only stayed visible when the tag-out animation happened to keep its node enabled (animations on, and only when leaving its home tag), which is why it works on some tags and not others.

## Fix
Skip set_arrange_hidden for grabc. Its position is already driven by the cursor every frame, and it gets retagged and re-tiled on release as before.

Tested on Void Linux, wlroots 0.20.2 / scenefx 0.5: preview stays under the cursor on empty and populated tags, animations on or off, any number of tag switches.
