### PR TITLE
feat: add maximized window rule

### DIFF
--- a/docs/window-management/rules.md
+++ b/docs/window-management/rules.md
@@ -23,6 +23,7 @@ windowrule=Parameter:Values,Parameter:Values,appid:Values,title:Values
 | `isfloating` | integer | `0` / `1` | Force floating state |
 | `isfullscreen` | integer | `0` / `1` | Force fullscreen state |
 | `isfakefullscreen` | integer | `0` / `1` | Force fake-fullscreen state (window stays constrained) |
+| `ismaximized` | integer | `0` / `1` | Force Mango's screen-maximize state (the same behavior as `togglemaximizescreen`) |
 | `isglobal` | integer | `0` / `1` | Open as global window (sticky across tags) |
 | `isoverlay` | integer | `0` / `1` | Make it always in top layer |
 | `isopensilent` | integer | `0` / `1` | Open without focus |

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -64,6 +64,7 @@ typedef struct {
 	int32_t isfloating;
 	int32_t isfullscreen;
 	int32_t isfakefullscreen;
+	int32_t ismaximized;
 	float scroller_proportion;
 	const char *animation_type_open;
 	const char *animation_type_close;
@@ -2393,6 +2394,7 @@ bool parse_option(Config *config, char *key, char *value) {
 		rule->isfloating = -1;
 		rule->isfullscreen = -1;
 		rule->isfakefullscreen = -1;
+		rule->ismaximized = -1;
 		rule->isnoborder = -1;
 		rule->isnoshadow = -1;
 		rule->isnoradius = -1;
@@ -2546,6 +2548,8 @@ bool parse_option(Config *config, char *key, char *value) {
 					rule->isfullscreen = atoi(val);
 				} else if (strcmp(key, "isfakefullscreen") == 0) {
 					rule->isfakefullscreen = atoi(val);
+				} else if (strcmp(key, "ismaximized") == 0) {
+					rule->ismaximized = atoi(val);
 				} else if (strcmp(key, "globalkeybinding") == 0) {
 					char mod_str[256], keysym_str[256];
 					sscanf(val, "%255[^-]-%255[a-zA-Z]", mod_str, keysym_str);

--- a/src/mango.c
+++ b/src/mango.c
@@ -1712,6 +1712,7 @@ void applyrules(Client *c) {
 	Monitor *m = NULL;
 	Client *fc = NULL;
 	Client *parent = NULL;
+	int32_t ismaximized = -1;
 
 	if (!c)
 		return;
@@ -1744,6 +1745,8 @@ void applyrules(Client *c) {
 
 		// set general properties
 		apply_rule_properties(c, r);
+		if (r->ismaximized >= 0)
+			ismaximized = r->ismaximized;
 
 		// // set tags
 		if (r->tags > 0) {
@@ -1865,6 +1868,9 @@ void applyrules(Client *c) {
 	}
 
 	setfullscreen(c, fullscreen_state_backup, true);
+
+	if (ismaximized >= 0)
+		setmaximizescreen(c, ismaximized, true);
 
 	if (c->isfakefullscreen) {
 		setfakefullscreen(c, 1);


### PR DESCRIPTION
## Summary
- add an `ismaximized:0|1` window-rule property
- apply Mango's existing screen-maximize state after the client maps
- document the new rule parameter

## Testing
- `meson compile -C build`
- parser validation with `windowrule=appid:foot,ismaximized:1`
- isolated headless Mango runtime test: a Foot client matched by the rule reported `is_maximized: true` and `is_fullscreen: false` over Mango IPC