### PR TITLE
chore: make format.sh executable and improve shebang portability

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 clang-format -i src/*/*.h -i  src/*/*.c -i  src/mango.c -i mmsg/mmsg.c


### PR DESCRIPTION
Edited scrip file permissions.
The shebang #!/usr/bin/bash doesn't work on e.g. NixOS. Using #!/usr/bin/env fixes that.