### PR TITLE
Fix/restore minimized

### DIFF
--- a/src/mango.c
+++ b/src/mango.c
@@ -6106,6 +6106,16 @@ void show_hide_client(Client *c) {
 
 	if (!c->is_in_scratchpad) {
 		tag_client(&(Arg){.ui = target}, c);
+		c->tags = target;
+		c->istagswitching = 1;
+		Client *fc = NULL;
+		wl_list_for_each(fc, &clients, link) {
+			if (fc && fc != c && c->tags & fc->tags && ISFULLSCREEN(fc) &&
+				!c->isfloating) {
+				clear_fullscreen_flag(fc);
+			}
+		}
+		view_in_mon(&(Arg){.ui = target}, true, c->mon, false);
 	} else {
 		c->tags = c->oldtags;
 		arrange(c->mon, false, false);

--- a/src/mango.c
+++ b/src/mango.c
@@ -6105,7 +6105,6 @@ void show_hide_client(Client *c) {
 	target = get_tags_first_tag(c->oldtags);
 
 	if (!c->is_in_scratchpad) {
-		tag_client(&(Arg){.ui = target}, c);
 		c->tags = target;
 		c->istagswitching = 1;
 		Client *fc = NULL;


### PR DESCRIPTION
Fixes #1211

`restore_minimized` calls `show_hide_client`, which called `tag_client()` which internally called `view()`, always operating on `selmon`. When restoring a minimized client from a different monitor than the client belongs to, the wrong monitor's tag
was switched, leaving the restored client invisible on its own monitor.

Fix by inlining the tag_client logic in `show_hide_client` and calling `view_in_mon` directly on the client's monitor (`c->mon`) instead of `selmon`, so the correct monitor switches to the restored client's tag.