### PR TITLE
fix(sessionlock): wait for first frame by screenlocker client

### DIFF
--- a/src/mango.c
+++ b/src/mango.c
@@ -603,6 +603,8 @@ typedef struct {
 	struct wl_listener new_surface;
 	struct wl_listener unlock;
 	struct wl_listener destroy;
+
+	bool sent_locked; /* have we sent locked yet */
 } SessionLock;
 
 struct capture_session_tracker {
@@ -910,7 +912,7 @@ static void last_cursor_surface_destroy(struct wl_listener *listener,
 static int32_t keep_idle_inhibit(void *data);
 static void check_keep_idle_inhibit(Client *c);
 static void pre_calculate_before_arrange(Monitor *m, bool want_animation,
-										bool from_view, bool only_calculate);
+										 bool from_view, bool only_calculate);
 static void client_pending_fullscreen_state(Client *c, int32_t isfullscreen);
 static void client_pending_maximized_state(Client *c, int32_t ismaximized);
 static void client_pending_minimized_state(Client *c, int32_t isminimized);
@@ -4584,7 +4586,10 @@ void locksession(struct wl_listener *listener, void *data) {
 	LISTEN(&session_lock->events.destroy, &lock->destroy, destroysessionlock);
 	LISTEN(&session_lock->events.unlock, &lock->unlock, unlocksession);
 
-	wlr_session_lock_v1_send_locked(session_lock);
+	if (config.allow_lock_transparent) {
+		wlr_session_lock_v1_send_locked(lock->lock);
+		lock->sent_locked = true;
+	}
 }
 
 static void iter_xdg_scene_buffers(struct wlr_scene_buffer *buffer, int32_t sx,
@@ -5429,6 +5434,7 @@ void rendermon(struct wl_listener *listener, void *data) {
 	struct wl_list *layer_list;
 	struct timespec now;
 	bool need_more_frames = false;
+	SessionLock *lock;
 
 	if (session && !session->active) {
 		return;
@@ -5474,6 +5480,15 @@ void rendermon(struct wl_listener *listener, void *data) {
 	}
 
 	mango_scene_output_commit(m->scene_output, &m->pending);
+
+	// If this is a lock_surface, send locked after this frame
+	if (m->lock_surface && cur_lock) {
+		lock = cur_lock->data;
+		if (!lock->sent_locked) {
+			wlr_session_lock_v1_send_locked(lock->lock);
+			lock->sent_locked = true;
+		}
+	}
 
 skip:
 	// 发送帧完成通知


### PR DESCRIPTION
### Context

The Session lock protocol[^1] requires us to ensure that we display frames by the screenlocker on all outputs before sending "locked", which we do by blanking all monitors to be gray (`locked_bg`). This can be circumvented with the `allow_lock_transparent` option but it's off by default (see https://github.com/mangowm/mango/pull/448)

### Issue / Fix

I've set up my screenlocker to run before suspend. I've noticed a problem using mango: The gray blank frame is shown on wake up because it was the last one to be drawn before sleeping. Then, on my machine, it persists for a few hundred milliseconds (normal wakup freeze) before reaching the screenlocker. This looked pretty jarring to me, going from black to gray to my screenlocker. Following "every frame is correct", I think this should be improved. This change makes mango wait for the first frame by the screenlocker and only then send "locked". If `allow_lock_transparent` is on, it keeps the old behavior (locking immediately).


This change diverges from the spec[^1]:
> The compositor may wait for the client to create and render session lock surfaces before sending the locked event to avoid displaying intermediate blank frames. However, it must impose a reasonable time limit if waiting and send the locked event as soon as the hard requirements described above can be met if the time limit expires. Clients should immediately create lock surfaces for all outputs on creation of this object to make this possible.

We don't have a timer as the spec would require. But a screenlocker not sending frames after requesting a lock is very unlikely and because we render blank frames (`locked_bg`), it's not a security concern. We could add a timer later but I decided against that code weight for now.

[^1]: https://wayland.app/protocols/ext-session-lock-v1#ext_session_lock_v1
