### PR TITLE
feat: add focus_first_tiled dispatcher

### DIFF
--- a/docs/bindings/keys.md
+++ b/docs/bindings/keys.md
@@ -110,6 +110,7 @@ bindr=Super,Super_L,spawn,rofi -show run
 | `focusdir` | `left/right/up/down` | Focus window in direction. |
 | `focus_window_or_workspace` | `left/right/up/down` | Focus window in direction or switch to next/previous workspace. |
 | `focusstack` | `next/prev` | Cycle focus within the stack. |
+| `focus_first_tiled` | - | Focus the first visible tiled window in layout order. |
 | `focuslast` | - | Focus the previously active window. |
 | `exchange_client` | `left/right/up/down` | Swap window with neighbor in direction. |
 | `exchange_stack_client` | `next/prev` | Exchange window position in stack. |

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -1022,6 +1022,8 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 	if (strcmp(func_name, "focusstack") == 0) {
 		func = focusstack;
 		(*arg).i = parse_circle_direction(arg_value);
+	} else if (strcmp(func_name, "focus_first_tiled") == 0) {
+		func = focus_first_tiled;
 	} else if (strcmp(func_name, "groupfocus") == 0) {
 		func = groupfocus;
 		(*arg).i = parse_circle_direction(arg_value);

--- a/src/dispatch/bind_declare.h
+++ b/src/dispatch/bind_declare.h
@@ -41,6 +41,7 @@ void toggleglobal(const Arg *arg);
 void incnmaster(const Arg *arg);
 void focusmon(const Arg *arg);
 void focusstack(const Arg *arg);
+void focus_first_tiled(const Arg *arg);
 void groupfocus(const Arg *arg);
 void chvt(const Arg *arg);
 void reload_config(const Arg *arg);

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -379,6 +379,26 @@ void focusstack(const Arg *arg) {
 	return;
 }
 
+void focus_first_tiled(const Arg *arg) {
+	Client *c = NULL;
+
+	if (!selmon || !selmon->pertag->ltidxs[selmon->pertag->curtag]->arrange)
+		return;
+
+	wl_list_for_each(c, &clients, link) {
+		if (VISIBLEON(c, selmon) && ISFAKETILED(c))
+			break;
+	}
+
+	if (&c->link == &clients || c == selmon->sel)
+		return;
+
+	focusclient(c, 1);
+	if (config.warpcursor)
+		warp_cursor(c);
+	return;
+}
+
 void groupfocus(const Arg *arg) {
 	Client *c = arg->tc ? arg->tc : selmon->sel;
 	if (!c || !c->mon)


### PR DESCRIPTION
This adds a `focus_first_tiled` dispatcher that focuses the first visible tiled window in layout order on the focused monitor. In a master/stack layout that's the master window.

I tried scripting this over IPC first, but `focusid` doesn't warp the cursor, so with sloppyfocus the focus snaps back as soon as the mouse moves.

The window is picked with the same `VISIBLEON`/`ISFAKETILED` walk the layout code uses, so it agrees with whatever the layout puts first (after zoom, nmaster changes and so on) and skips floating windows. If there's no eligible window, or it's already focused, it does nothing, so the cursor never warps without reason.

I've been running this daily for about two weeks without issues.

I think this fits as core functionality, but no hard feelings if you see it differently.

