### PR TITLE
feat: add dwindle_toggle_current_split dispatch

### DIFF
--- a/docs/bindings/keys.md
+++ b/docs/bindings/keys.md
@@ -167,6 +167,7 @@ It is formed by tag numbers `1`–`9`, optionally combined with `|`.
 |  `dwindle_toggle_split_direction` | - | Toggle split direction in dwindle layout. |
 | `dwindle_split_horizontal` | - | Set split window direction to horizontal in dwindle layout. |
 | `dwindle_split_vertical` | - | Set split window direction to vertical in dwindle layout. |
+| `dwindle_toggle_current_split` | - | Toggle split direction of current window in dwindle layout. |
 
 ### System
 

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -1331,6 +1331,8 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 		func = dwindle_split_horizontal;
 	} else if (strcmp(func_name, "dwindle_split_vertical") == 0) {
 		func = dwindle_split_vertical;
+	} else if (strcmp(func_name, "dwindle_toggle_current_split") == 0) {
+		func = dwindle_toggle_current_split;
 	} else {
 		return NULL;
 	}

--- a/src/dispatch/bind_declare.h
+++ b/src/dispatch/bind_declare.h
@@ -83,4 +83,5 @@ void toggle_all_floating(const Arg *arg);
 void dwindle_toggle_split_direction(const Arg *arg);
 void dwindle_split_horizontal(const Arg *arg);
 void dwindle_split_vertical(const Arg *arg);
+void dwindle_toggle_current_split(const Arg *arg);
 void focusid(const Arg *arg);

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -2185,7 +2185,6 @@ void dwindle_set_split_direction(Client *c, bool istoggle, bool horizontal) {
 		return;
 
 	if (istoggle) {
-		// NOTE: we do this
 		leaf->custom_leaf_split_h = !leaf->custom_leaf_split_h;
 	} else if (horizontal) {
 		leaf->custom_leaf_split_h = true;

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -2238,7 +2238,7 @@ void dwindle_toggle_current_split(const Arg *arg) {
 	if (layout->id != DWINDLE)
 		return;
 
-	DwindleNode *root = c->mon->pertag->dwindle_root[selmon->pertag->curtag];
+	DwindleNode *root = c->mon->pertag->dwindle_root[c->mon->pertag->curtag];
 	DwindleNode *leaf = dwindle_find_leaf(root, c);
 	if (!leaf || !leaf->parent)
 		return; 

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -2238,7 +2238,7 @@ void dwindle_toggle_current_split(const Arg *arg) {
 	if (layout->id != DWINDLE)
 		return;
 
-	DwindleNode *root = selmon->pertag->dwindle_root[selmon->pertag->curtag];
+	DwindleNode *root = c->mon->pertag->dwindle_root[selmon->pertag->curtag];
 	DwindleNode *leaf = dwindle_find_leaf(root, c);
 	if (!leaf || !leaf->parent)
 		return; 

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -2185,6 +2185,7 @@ void dwindle_set_split_direction(Client *c, bool istoggle, bool horizontal) {
 		return;
 
 	if (istoggle) {
+		// NOTE: we do this
 		leaf->custom_leaf_split_h = !leaf->custom_leaf_split_h;
 	} else if (horizontal) {
 		leaf->custom_leaf_split_h = true;
@@ -2225,6 +2226,29 @@ void dwindle_split_vertical(const Arg *arg) {
 	if (!c || !c->mon || c->isfloating)
 		return;
 	dwindle_set_split_direction(c, false, false);
+}
+
+void dwindle_toggle_current_split(const Arg *arg) {
+	if (!selmon)
+		return;
+	Client *c = arg->tc ? arg->tc : selmon->sel;
+	if (!c || !c->mon || c->isfloating)
+		return;
+
+	const Layout *layout = c->mon->pertag->ltidxs[c->mon->pertag->curtag];
+	if (layout->id != DWINDLE)
+		return;
+
+	DwindleNode *root = selmon->pertag->dwindle_root[selmon->pertag->curtag];
+	DwindleNode *leaf = dwindle_find_leaf(root, c);
+	if (!leaf || !leaf->parent)
+		return; 
+
+	DwindleNode *parent = leaf->parent;
+	parent->split_h = !parent->split_h;
+	parent->split_locked = true;
+
+	arrange(c->mon, false, false);
 }
 
 void focusid(const Arg *arg) {


### PR DESCRIPTION
Toggles the parent split node's split_h on the focused window and reflows immediately, unlike dwindle_toggle_split_direction which only affects future window placement.

3 files changed:
- bind_declare.h — declaration
- bind_define.h — finds leaf → parent, flips split_h, sets split_locked=true, calls arrange()
- parse_config.h — register "dwindle_toggle_current_split" in parse_func_name()

Keybind example: bind = Super, S, dwindle_toggle_current_split