### PR TITLE
fix(nix): disable upstream nixpkgs programs.mango module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,12 +8,13 @@
     };
   };
 
-  outputs = {
-    self,
-    flake-parts,
-    ...
-  } @ inputs:
-    flake-parts.lib.mkFlake {inherit inputs;} {
+  outputs =
+    {
+      self,
+      flake-parts,
+      ...
+    }@inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
         inputs.flake-parts.flakeModules.easyOverlay
       ];
@@ -23,38 +24,41 @@
         nixosModules.mango = import ./nix/nixos-modules.nix self;
       };
 
-      perSystem = {
-        config,
-        pkgs,
-        ...
-      }: let
-        inherit (pkgs) callPackage;
-        mango = callPackage ./nix {
-          scenefx = inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}.default;
-        };
-        shellOverride = old: {
-          nativeBuildInputs = old.nativeBuildInputs ++ [];
-          buildInputs = old.buildInputs ++ [];
-        };
-      in {
-        packages.default = mango;
-        overlayAttrs = {
-          inherit (config.packages) mango;
-        };
-        packages = {
-          inherit mango;
-          hm-options-json = pkgs.callPackage (import ./nix/generate-options.nix self) {
-            module = ./nix/hm-modules.nix;
-            optionPrefix = "wayland.windowManager.mango.";
+      perSystem =
+        {
+          config,
+          pkgs,
+          ...
+        }:
+        let
+          inherit (pkgs) callPackage;
+          mango = callPackage ./nix {
+            scenefx = inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}.default;
           };
-          nixos-options-json = pkgs.callPackage (import ./nix/generate-options.nix self) {
-            module = ./nix/nixos-modules.nix;
-            optionPrefix = "programs.mango.";
+          shellOverride = old: {
+            nativeBuildInputs = old.nativeBuildInputs ++ [ ];
+            buildInputs = old.buildInputs ++ [ ];
           };
+        in
+        {
+          packages.default = mango;
+          overlayAttrs = {
+            inherit (config.packages) mango;
+          };
+          packages = {
+            inherit mango;
+            hm-options-json = pkgs.callPackage (import ./nix/generate-options.nix self) {
+              module = ./nix/hm-modules.nix;
+              optionPrefix = "wayland.windowManager.mango.";
+            };
+            nixos-options-json = pkgs.callPackage (import ./nix/generate-options.nix self) {
+              module = ./nix/nixos-modules.nix;
+              optionPrefix = "programs.mango.";
+            };
+          };
+          devShells.default = mango.overrideAttrs shellOverride;
+          formatter = pkgs.nixfmt;
         };
-        devShells.default = mango.overrideAttrs shellOverride;
-        formatter = pkgs.alejandra;
-      };
       systems = [
         "x86_64-linux"
         "aarch64-linux"

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -45,30 +45,29 @@ stdenv.mkDerivation {
     wayland-scanner
   ];
 
-  buildInputs =
-    [
-      libinput
-      libxcb
-      libxkbcommon
-      pcre2
-      pango
-      cjson
-      pixman
-      wayland
-      wayland-protocols
-      wlroots_0_20
-      scenefx
-      libGL
-      libdrm
-    ]
-    ++ lib.optionals enableXWayland [
-      libX11
-      libxcb-wm
-      xwayland
-    ];
+  buildInputs = [
+    libinput
+    libxcb
+    libxkbcommon
+    pcre2
+    pango
+    cjson
+    pixman
+    wayland
+    wayland-protocols
+    wlroots_0_20
+    scenefx
+    libGL
+    libdrm
+  ]
+  ++ lib.optionals enableXWayland [
+    libX11
+    libxcb-wm
+    xwayland
+  ];
 
   passthru = {
-    providedSessions = ["mango"];
+    providedSessions = [ "mango" ];
   };
 
   meta = {
@@ -76,7 +75,7 @@ stdenv.mkDerivation {
     description = "Practical and Powerful wayland compositor (dwm but wayland)";
     homepage = "https://github.com/mangowm/mango";
     license = lib.licenses.gpl3Plus;
-    maintainers = [];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 }

--- a/nix/nixos-modules.nix
+++ b/nix/nixos-modules.nix
@@ -1,12 +1,15 @@
-self: {
+self:
+{
   config,
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   cfg = config.programs.mango;
-in {
-  disabledModules = ["programs/wayland/mango.nix"];
+in
+{
+  disabledModules = [ "programs/wayland/mango.nix" ];
 
   options = {
     programs.mango = {
@@ -25,10 +28,9 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages =
-      [
-        cfg.package
-      ];
+    environment.systemPackages = [
+      cfg.package
+    ];
 
     xdg.portal = {
       enable = lib.mkDefault true;
@@ -39,12 +41,12 @@ in {
             "gtk"
           ];
           # except those
-          "org.freedesktop.impl.portal.Secret" = ["gnome-keyring"];
-          "org.freedesktop.impl.portal.ScreenCast" = ["wlr"];
-          "org.freedesktop.impl.portal.Screenshot" = ["wlr"];
+          "org.freedesktop.impl.portal.Secret" = [ "gnome-keyring" ];
+          "org.freedesktop.impl.portal.ScreenCast" = [ "wlr" ];
+          "org.freedesktop.impl.portal.Screenshot" = [ "wlr" ];
 
           # wlr does not have this interface
-          "org.freedesktop.impl.portal.Inhibit" = [];
+          "org.freedesktop.impl.portal.Inhibit" = [ ];
         };
       };
       extraPortals = with pkgs; [
@@ -54,7 +56,7 @@ in {
 
       wlr.enable = lib.mkDefault true;
 
-      configPackages = [cfg.package];
+      configPackages = [ cfg.package ];
     };
 
     security.polkit.enable = lib.mkDefault true;

--- a/nix/nixos-modules.nix
+++ b/nix/nixos-modules.nix
@@ -6,6 +6,8 @@ self: {
 }: let
   cfg = config.programs.mango;
 in {
+  disabledModules = ["programs/wayland/mango.nix"];
+
   options = {
     programs.mango = {
       enable = lib.mkEnableOption "mango, a wayland compositor based on dwl";


### PR DESCRIPTION
## Disable upstream nixpkgs `programs.mango` module

Fixes #1233

nixpkgs recently added its own `programs.mango` module (previously
`programs.mangowc`), which collides with this flake's
`nixosModules.mango` since both declare `programs.mango.*`. Evaluating
a system with both imported fails:

```
error: The option `programs.mango.enable' ... is already declared in ...
```

First commit adds `disabledModules = [ "programs/wayland/mango.nix" ]`
to `nix/nixos-modules.nix` so nixpkgs's copy is disabled automatically
whenever `nixosModules.mango` is imported.

Second commit switches the flake `formatter` from `alejandra` to the
official nixpkgs formatter, `nixfmt`, and reformats the touched files
accordingly.

Tested: eval and full rebuild succeed, `mango -v` runs fine post-build,
`nix flake check --all-systems` passes.