### PR TITLE
nix: remove scenefx and its dependencies in wl-only

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,27 +18,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": [
-          "scenefx",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1783279667,
@@ -73,45 +52,7 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
-        "scenefx": "scenefx"
-      }
-    },
-    "scenefx": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1782624992,
-        "narHash": "sha256-vUjLG6eubEhJJVa9LPygIcVmNoHwYbSUTJcWEcbxnU4=",
-        "owner": "wlrfx",
-        "repo": "scenefx",
-        "rev": "37ccd723bef49e6891156ffafce8f549f01446cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "wlrfx",
-        "repo": "scenefx",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
-        "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default-linux",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,6 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    scenefx = {
-      url = "github:wlrfx/scenefx";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
@@ -32,9 +28,7 @@
         }:
         let
           inherit (pkgs) callPackage;
-          mango = callPackage ./nix {
-            scenefx = inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}.default;
-          };
+          mango = callPackage ./nix {};
           shellOverride = old: {
             nativeBuildInputs = old.nativeBuildInputs ++ [ ];
             buildInputs = old.buildInputs ++ [ ];

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -18,9 +18,7 @@
   xwayland,
   meson,
   ninja,
-  scenefx,
   wlroots_0_20,
-  libGL,
   enableXWayland ? true,
   debug ? false,
 }:
@@ -56,8 +54,6 @@ stdenv.mkDerivation {
     wayland
     wayland-protocols
     wlroots_0_20
-    scenefx
-    libGL
     libdrm
   ]
   ++ lib.optionals enableXWayland [


### PR DESCRIPTION
Even within Mango’s wl-only branch, it still depends on scenefx for Nix. This PR removes scenefx and its dependency for wl-only.