### PR TITLE
fix: activate pointer constraints on layer-shell surfaces

### DIFF
--- a/src/mango.c
+++ b/src/mango.c
@@ -3902,6 +3902,13 @@ void createpointerconstraint(struct wl_listener *listener, void *data) {
 	LISTEN(&pointer_constraint->constraint->events.destroy,
 		   &pointer_constraint->destroy, destroypointerconstraint);
 
+	// layer surfaces are never selmon->sel, so match pointer focus too
+	if (seat->pointer_state.focused_surface ==
+		pointer_constraint->constraint->surface) {
+		cursorconstrain(pointer_constraint->constraint);
+		return;
+	}
+
 	if (!selmon || !selmon->sel)
 		return;
 
@@ -5375,7 +5382,21 @@ void pointerfocus(Client *c, struct wlr_surface *surface, double sx, double sy,
 	if (!c || !c->mon || !c->mon->isoverview) {
 		// don't let window get pointer focus,
 		// avoid game window force grab pointer in overview mode
+		struct wlr_surface *old_focus = seat->pointer_state.focused_surface;
 		wlr_seat_pointer_notify_enter(seat, surface, sx, sy);
+
+		// toplevel constraints are handled by focusclient, this picks up the
+		// ones focusclient can't see
+		if (!c && surface != old_focus) {
+			struct wlr_pointer_constraint_v1 *constraint;
+			wl_list_for_each(constraint, &pointer_constraints->constraints,
+							 link) {
+				if (constraint->surface == surface) {
+					cursorconstrain(constraint);
+					break;
+				}
+			}
+		}
 	}
 
 	wlr_seat_pointer_notify_motion(seat, time, sx, sy);

--- a/src/mango.c
+++ b/src/mango.c
@@ -3903,6 +3903,7 @@ void createpointerconstraint(struct wl_listener *listener, void *data) {
 		   &pointer_constraint->destroy, destroypointerconstraint);
 
 	// layer surfaces are never selmon->sel, so match pointer focus too
+	// (e.g. lan-mouse locks the pointer on a 1px layer surface)
 	if (seat->pointer_state.focused_surface ==
 		pointer_constraint->constraint->surface) {
 		cursorconstrain(pointer_constraint->constraint);
@@ -5363,6 +5364,15 @@ void pointerfocus(Client *c, struct wlr_surface *surface, double sx, double sy,
 		 (selmon && selmon->isoverview && selmon->sel != c)) &&
 		!client_is_unmanaged(c) && VISIBLEON(c, c->mon))
 		focusclient(c, 0);
+
+	/* Pointer-driven layer constraints: deactivate as soon as the pointer
+	 * leaves their surface. Toplevel constraints are managed by focusclient
+	 * (keyboard focus driven), so they are left untouched here. */
+	if (active_constraint && surface != seat->pointer_state.focused_surface &&
+		toplevel_from_wlr_surface(active_constraint->surface, NULL, NULL) ==
+			LayerShell) {
+		cursorconstrain(NULL);
+	}
 
 	/* If surface is NULL, clear pointer focus */
 	if (!surface) {


### PR DESCRIPTION
Fixes #1080

## Problem

#865 fixed the `motionnotify` half of this, but nothing ever sets
`active_constraint` for a layer surface, so that code is never reached.

`active_constraint` is only set in two places, and both look for a toplevel:
`createpointerconstraint` compares against `client_surface(selmon->sel)`, and
`focusclient` searches the constraint list for `client_surface(c)`. A layer
surface is never `selmon->sel`, so `lock_pointer` from one is accepted but never
activated — `send_activated` is never sent, the cursor keeps moving, leaves the
surface, and the client gets a `leave`.

lan-mouse locks the pointer on a 1px layer surface, so capture only holds while
the cursor sits exactly on the border strip and drops as soon as it moves off.

## Fix

- `createpointerconstraint` — also match `seat->pointer_state.focused_surface`,
  for clients that lock from their pointer enter handler.
- `pointerfocus` — activate a constraint on the focused surface when it has no
  client (`xytonode` returns layer surfaces through `pl`, never `pc`).
  Activate-only, so it won't grab the pointer for an unfocused window with
  `sloppyfocus=0`.

Tested on 0.15.5, CachyOS, wlroots 0.20, with lan-mouse's layer-shell capture
backend. Confirmed via `WAYLAND_DEBUG=client` that `zwp_locked_pointer_v1.locked`
now reaches the client; before the change it never arrived.
