### PR TITLE
xdg-output: make resources inert on output removal instead of destroying them

### DIFF
--- a/src/ext-protocol/xdg-output.h
+++ b/src/ext-protocol/xdg-output.h
@@ -155,12 +155,23 @@ static void xdg_output_update_all(void) {
 	}
 }
 
-/* 销毁指定输出对应的所有 xdg-output 资源（monitor 移除时调用） */
+/* 输出被移除时，让对应的 xdg-output 资源变为惰性，而不是销毁它 */
 static void xdg_output_cleanup_output(struct wlr_output *wlr_output) {
 	struct MangoXDGOutput *output, *tmp;
 	wl_list_for_each_safe(output, tmp, &xdg_output_resources, link) {
-		if (output->wlr_output == wlr_output)
-			wl_resource_destroy(output->resource);
+		if (output->wlr_output != wlr_output)
+			continue;
+
+		/* zxdg_output_v1 is created by the client, so only the client may
+		 * destroy it. Destroying it here makes libwayland send delete_id for
+		 * that id; the client then reuses the id while its own destroy request
+		 * is still in flight, and the next request hits an unknown object.
+		 * wlroots makes such resources inert instead -- do the same.
+		 * xdg_output_handle_resource_destroy() already returns early on NULL
+		 * user data, so the client's later destroy is a no-op. */
+		wl_resource_set_user_data(output->resource, NULL);
+		wl_list_remove(&output->link);
+		free(output);
 	}
 }
 


### PR DESCRIPTION
Unplugging a display kills every client holding a `zxdg_output_v1` for it. With a layer-shell bar running, that takes down the bar and the shell, so the whole session looks like it crashed.

`xdg_output_cleanup_output()` calls `wl_resource_destroy()` on an object created by the **client**. libwayland then sends `wl_display.delete_id` for that id, the client treats the id as free and reuses it for its next object, while its own legitimate `destroy` request is still in flight. The compositor receives a request for an id it no longer knows and answers with a fatal `invalid object`, which kills the client.

Captured with `WAYLAND_DEBUG=1` while unplugging a DisplayPort output. Object 30 was that output`s `zxdg_output_v1`:

```
 -> get_xdg_output(new id zxdg_output_v1#30, wl_output#29)
    zxdg_output_v1#30.name("DP-2")
    wl_display#1.delete_id(30)          <- 01.901800  compositor frees the id
 -> zxdg_output_v1#30.destroy()         <- 01.902551  client destroys after
 -> create_immed(new id wl_buffer#30)   <- id reused
 -> wl_surface#48.attach(wl_buffer#30)
    wl_display#1.error(..., "invalid object 30")
```

The client then dies with `failed to dispatch pending Wayland events after poll: display_error=22`.

wlroots never destroys client-created resources this way — layer surfaces, ext-workspace group handles and `wl_output` all keep the resource alive and only clear its user data. This does the same: drop our own bookkeeping and leave the client object alone. `xdg_output_handle_resource_destroy()` already returns early on NULL user data, so the client`s later destroy is a no-op.

Tested on wlroots 0.20.2 / amdgpu: unplugging an external DisplayPort output no longer kills the client. Formatted with `format.sh`; single commit.