### PR TITLE
hdr: mastering display metadata, runtime toggle, and damage on image description change

### DIFF
--- a/docs/configuration/monitors.md
+++ b/docs/configuration/monitors.md
@@ -31,6 +31,10 @@ monitorrule=name:Values,Parameter:Values,Parameter:Values
 | `scale` | float | 0.01-100.0 | Monitor scale |
 | `vrr` | integer | 0, 1 | Enable variable refresh rate |
 | `hdr` | integer | 0, 1 | Enable hdr support |
+| `hdr_min_lum` | float | 0.0-10000.0 | Mastering display minimum luminance, cd/m² (0 = unset) |
+| `hdr_max_lum` | float | 0.0-10000.0 | Mastering display peak luminance, also sent as max_cll, cd/m² (0 = unset) |
+| `hdr_max_avg_lum` | float | 0.0-10000.0 | Max frame-average light level (max_fall), cd/m² (0 = unset) |
+| `hdr_force` | integer | 0, 1 | Enable HDR even when the EDID does not advertise BT.2020/PQ |
 | `rr` | integer | 0-7 | Monitor transform |
 | `custom` | integer | 0, 1 | Enable custom mode (not supported on all displays — may cause black screen) |
 | `disable` | integer | 0, 1 | Disable the monitor |
@@ -119,6 +123,60 @@ Tearing allows games to bypass the compositor's VSync for lower latency.
 env=WLR_RENDERER,vulkan
 monitorrule=name:eDP-1,model:0x15F5,width:1920,height:1080,refresh:60,x:0,y:0,scale:1,vrr:0,rr:0:hdr:1
 ```
+
+### Toggling HDR at runtime
+
+`monitorrule` sets the state at startup; `togglehdr` changes it without a config
+reload, the way sway's `output <name> hdr on|off|toggle` does.
+
+```sh
+mmsg dispatch togglehdr              # toggle the focused monitor
+mmsg dispatch togglehdr,on           # force on
+mmsg dispatch togglehdr,off,eDP-1    # a named output
+mmsg dispatch togglehdr,toggle,all   # every output at once
+```
+
+With no argument it toggles the focused monitor. Reloading the config re-applies
+`monitorrule` and overrides whatever `togglehdr` last set.
+
+`all` applies to every enabled output. In toggle mode it makes one decision for
+all of them — if anything is on, everything goes off — rather than flipping each
+output against its own state. Outputs that cannot do HDR are skipped without
+their state being touched.
+
+### Mastering display metadata
+
+`hdr:1` alone declares BT.2020 primaries and the PQ transfer function, but leaves
+the mastering display fields at zero, so the panel has nothing to tone-map
+against. Set them to your panel's values:
+
+```ini
+monitorrule=name:eDP-1,...,hdr:1,hdr_max_lum:616,hdr_max_avg_lum:400
+```
+
+`di-edid-decode` prints them under *HDR Static Metadata Data Block*. `hdr_max_lum`
+is sent both as the mastering peak and as max_cll. Leaving any of the three at `0`
+leaves that field unset, which is the previous behaviour.
+
+> `hdr_min_lum` has no effect on wlroots 0.20.x: the minimum was scaled the wrong
+> way in `backend/drm/atomic.c` and every value underflowed to 0. Fixed upstream
+> by wlroots commit `f6a01b40`, not backported to the 0.20 branch.
+
+### Panels whose EDID hides the HDR block
+
+Some panels declare HDR only inside a **DisplayID 2.0** extension, with the
+CTA-861 blocks nested in a container (tag `0x81`). This is legal EDID 1.4, but
+wlroots reads HDR capability through libdisplay-info's CTA path and comes back
+empty, so `hdr:1` is silently ignored on a panel that handles PQ.
+
+`hdr_force:1` skips the two EDID-derived checks:
+
+```ini
+monitorrule=name:eDP-1,...,hdr:1,hdr_force:1,hdr_max_lum:616,hdr_max_avg_lum:400
+```
+
+It does not skip the renderer check: output colour transforms only exist in the
+Vulkan renderer, so `WLR_RENDERER=vulkan` is still required.
 
 
 ### Configuration

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -122,6 +122,10 @@ typedef struct {
 	int32_t vrr;				 // variable refresh rate
 	int32_t custom;				 // enable custom mode
 	int32_t hdr;				 // enable hdr mode
+	float hdr_min_lum;			 // mastering min luminance, cd/m² (0 = unset)
+	float hdr_max_lum;			 // mastering max luminance / max_cll, cd/m²
+	float hdr_max_avg_lum;		 // max frame-average light level, cd/m²
+	int32_t hdr_force;			 // ignore EDID-derived HDR capability checks
 	int32_t disable;			 // prefer disable
 } ConfigMonitorRule;
 
@@ -1129,6 +1133,20 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 		(*arg).i = parse_circle_direction(arg_value);
 	} else if (strcmp(func_name, "toggleglobal") == 0) {
 		func = toggleglobal;
+	} else if (strcmp(func_name, "togglehdr") == 0) {
+		/* togglehdr[,on|off|toggle][,<monitor name>|all] */
+		func = togglehdr;
+		if (strcmp(arg_value, "on") == 0)
+			(*arg).i = 1;
+		else if (strcmp(arg_value, "off") == 0)
+			(*arg).i = 0;
+		else
+			(*arg).i = -1; // toggle, and the default for an empty argument
+		// "not given" is "" from the IPC path and "0" from the keybinding
+		// parser -- same rule as combine_args_until_empty().
+		bool has_name = arg_value2 && arg_value2[0] != '\0' &&
+						!(strlen(arg_value2) == 1 && arg_value2[0] == '0');
+		(*arg).v = has_name ? strdup(arg_value2) : NULL;
 	} else if (strcmp(func_name, "toggleoverview") == 0) {
 		func = toggleoverview;
 		(*arg).i = atoi(arg_value);
@@ -2190,6 +2208,10 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 		rule->refresh = 0.0f;
 		rule->vrr = 0;
 		rule->hdr = 0;
+		rule->hdr_min_lum = 0.0f;
+		rule->hdr_max_lum = 0.0f;
+		rule->hdr_max_avg_lum = 0.0f;
+		rule->hdr_force = 0;
 		rule->custom = 0;
 		rule->disable = 0;
 
@@ -2231,6 +2253,17 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 					rule->vrr = CLAMP_INT(atoi(val), 0, 1);
 				} else if (strcmp(key, "hdr") == 0) {
 					rule->hdr = CLAMP_INT(atoi(val), 0, 1);
+				} else if (strcmp(key, "hdr_min_lum") == 0) {
+					// cd/m². OLED blacks sit well below 0.01, so the floor has
+					// to allow small fractions -- do not clamp to >= 1.
+					rule->hdr_min_lum = CLAMP_FLOAT(atof(val), 0.0f, 10000.0f);
+				} else if (strcmp(key, "hdr_max_lum") == 0) {
+					rule->hdr_max_lum = CLAMP_FLOAT(atof(val), 0.0f, 10000.0f);
+				} else if (strcmp(key, "hdr_max_avg_lum") == 0) {
+					rule->hdr_max_avg_lum =
+						CLAMP_FLOAT(atof(val), 0.0f, 10000.0f);
+				} else if (strcmp(key, "hdr_force") == 0) {
+					rule->hdr_force = CLAMP_INT(atoi(val), 0, 1);
 				} else if (strcmp(key, "disable") == 0) {
 					rule->disable = CLAMP_INT(atoi(val), 0, 1);
 				} else if (strcmp(key, "custom") == 0) {

--- a/src/dispatch/bind_declare.h
+++ b/src/dispatch/bind_declare.h
@@ -6,6 +6,7 @@ void focus_window_or_workspace(const Arg *arg);
 void groupjoin(const Arg *arg);
 void groupleave(const Arg *arg);
 void toggleoverview(const Arg *arg);
+void togglehdr(const Arg *arg);
 void togglejump(const Arg *arg);
 void set_proportion(const Arg *arg);
 void switch_proportion_preset(const Arg *arg);

--- a/src/ext-protocol/hdr.h
+++ b/src/ext-protocol/hdr.h
@@ -49,13 +49,18 @@ static enum render_bit_depth bit_depth_from_format(uint32_t render_format) {
 	return MANGO_RENDER_BIT_DEPTH_DEFAULT;
 }
 
-static bool output_supports_hdr(const struct wlr_output *output,
-								const char **reason) {
+static bool output_supports_hdr(const Monitor *m, const char **reason) {
+	const struct wlr_output *output = m->wlr_output;
 	const char *r = NULL;
-	if (!(output->supported_primaries & WLR_COLOR_NAMED_PRIMARIES_BT2020))
+
+	// hdr_force skips the two EDID-derived checks, for panels that declare HDR
+	// only inside a DisplayID 2.0 extension. It does not skip the third:
+	// output_color_transform is a renderer capability, not an EDID claim.
+	if (!m->hdr_force &&
+		!(output->supported_primaries & WLR_COLOR_NAMED_PRIMARIES_BT2020))
 		r = "BT2020 primaries not supported";
-	else if (!(output->supported_transfer_functions &
-			   WLR_COLOR_TRANSFER_FUNCTION_ST2084_PQ))
+	else if (!m->hdr_force && !(output->supported_transfer_functions &
+								WLR_COLOR_TRANSFER_FUNCTION_ST2084_PQ))
 		r = "PQ transfer function not supported";
 	else if (!drw->features.output_color_transform)
 		r = "renderer doesn't support output color transforms";
@@ -70,7 +75,7 @@ void output_enable_hdr(Monitor *m, struct wlr_output_state *os, bool enabled,
 	if (!m->is_hdr_enabling && !enabled)
 		return;
 
-	if (!output_supports_hdr(m->wlr_output, NULL)) {
+	if (!output_supports_hdr(m, NULL)) {
 		m->is_hdr_enabling = false;
 		return;
 	}
@@ -93,6 +98,19 @@ void output_enable_hdr(Monitor *m, struct wlr_output_state *os, bool enabled,
 		.primaries = WLR_COLOR_NAMED_PRIMARIES_BT2020,
 		.transfer_function = WLR_COLOR_TRANSFER_FUNCTION_ST2084_PQ,
 	};
+
+	// Mastering display metadata, from the monitorrule: wlroots does not expose
+	// the EDID luminances. Values are in cd/m²; 0 means unset and leaves the
+	// field zero, which is the previous behaviour.
+	if (m->hdr_max_lum > 0) {
+		wlr_color_primaries_from_named(&desc.mastering_display_primaries,
+									   WLR_COLOR_NAMED_PRIMARIES_BT2020);
+		desc.mastering_luminance.min = m->hdr_min_lum;
+		desc.mastering_luminance.max = m->hdr_max_lum;
+		desc.max_cll = m->hdr_max_lum;
+		desc.max_fall = m->hdr_max_avg_lum;
+	}
+
 	m->is_hdr_enabling = true;
 	wlr_output_state_set_image_description(os, &desc);
 }
@@ -101,8 +119,7 @@ void output_state_setup_hdr(Monitor *m, bool silent,
 							struct wlr_output_state *state) {
 	uint32_t render_format = m->wlr_output->render_format;
 	const char *unsupported_reason = NULL;
-	bool hdr_supported =
-		output_supports_hdr(m->wlr_output, &unsupported_reason);
+	bool hdr_supported = output_supports_hdr(m, &unsupported_reason);
 	bool hdr_succeeded = false;
 
 	if (!hdr_supported) {
@@ -144,4 +161,116 @@ void output_state_setup_hdr(Monitor *m, bool silent,
 	}
 
 	output_enable_hdr(m, state, hdr_succeeded, silent);
+}
+
+/* togglehdr[,on|off|toggle][,<monitor name>|all] -- apply to one output */
+static bool togglehdr_output(Monitor *target, bool want) {
+	if (!target || !target->wlr_output->enabled || !target->scene_output)
+		return false;
+
+	if (want == target->hdr_enable)
+		return false;
+
+	// Check before mutating, so a refusal leaves the state untouched. This is
+	// also what makes the "all" form safe when some outputs are SDR.
+	const char *reason = NULL;
+	if (want && !output_supports_hdr(target, &reason)) {
+		wlr_log(WLR_INFO, "togglehdr: HDR unavailable on %s: %s",
+				target->wlr_output->name, reason);
+		return false;
+	}
+
+	// Snapshot both flags: output_enable_hdr() writes is_hdr_enabling before
+	// the commit is attempted, so a failed commit must restore both or the two
+	// disagree -- mango would render SDR on a connector still in PQ.
+	bool prev_enable = target->hdr_enable;
+	bool prev_enabling = target->is_hdr_enabling;
+
+	target->hdr_enable = want;
+
+	if (want)
+		output_state_setup_hdr(target, false, &target->pending);
+	else
+		output_enable_hdr(target, &target->pending, false, false);
+
+	// wlroots damages the whole output for a geometry, transform, scale or
+	// rendered gamma LUT change, but not for an image description change, which
+	// also changes how every pixel is encoded. Without this, anything left
+	// undamaged keeps the luminance mapping it had when last drawn.
+	wlr_output_schedule_frame(target->wlr_output);
+	wlr_damage_ring_add_whole(&target->scene_output->damage_ring);
+
+	// Swapping the image description reconfigures the output; wlroots refuses
+	// such a commit unless the disruption is explicitly allowed.
+	target->pending.allow_reconfiguration = true;
+
+	// force = true: mango_scene_output_commit() returns early when
+	// wlr_scene_output_needs_frame() is false, and a still screen would
+	// otherwise swallow the change.
+	if (!mango_scene_output_commit(target->scene_output, &target->pending,
+								   true)) {
+		wlr_log(WLR_ERROR, "togglehdr: commit failed on %s, reverting",
+				target->wlr_output->name);
+		target->hdr_enable = prev_enable;
+		target->is_hdr_enabling = prev_enabling;
+		// The commit helper only recycles pending on success.
+		wlr_output_state_finish(&target->pending);
+		wlr_output_state_init(&target->pending);
+		return false;
+	}
+
+	wlr_output_effective_resolution(target->wlr_output, &target->m.width,
+									&target->m.height);
+	return true;
+}
+
+void togglehdr(const Arg *arg) {
+	// arg->i: 1 = on, 0 = off, -1 = toggle (also the default when no argument
+	// was given, so a bare `togglehdr` binding does the obvious thing).
+	if (arg->v && strcmp(arg->v, "all") == 0) {
+		Monitor *m = NULL;
+		bool want;
+
+		if (arg->i < 0) {
+			// One decision for every output: flipping each against its own
+			// state would leave a multi-monitor desk half on and half off, and
+			// the next press would swap the halves instead of converging.
+			bool any_on = false;
+			wl_list_for_each(m, &mons, link) {
+				if (m->wlr_output->enabled && m->hdr_enable) {
+					any_on = true;
+					break;
+				}
+			}
+			want = !any_on;
+		} else {
+			want = arg->i != 0;
+		}
+
+		wl_list_for_each(m, &mons, link) togglehdr_output(m, want);
+		return;
+	}
+
+	Monitor *m = NULL, *target = NULL;
+
+	if (arg->v && *arg->v) {
+		wl_list_for_each(m, &mons, link) {
+			if (m->wlr_output->enabled &&
+				strcmp(m->wlr_output->name, arg->v) == 0) {
+				target = m;
+				break;
+			}
+		}
+		if (!target) {
+			wlr_log(WLR_ERROR, "togglehdr: no enabled output named %s", arg->v);
+			return;
+		}
+	} else {
+		target = selmon;
+	}
+
+	if (!target)
+		return;
+
+	togglehdr_output(target, arg->i < 0 ? !target->hdr_enable : (arg->i != 0));
 }

--- a/src/mango.c
+++ b/src/mango.c
@@ -602,6 +602,12 @@ struct Monitor {
 	bool hdr_enable;
 	bool prefer_disable;
 	bool is_hdr_enabling;
+	// Mastering display metadata, in cd/m². 0 = unset, see output_enable_hdr().
+	float hdr_min_lum;
+	float hdr_max_lum;
+	float hdr_max_avg_lum;
+	// Bypass the EDID-derived capability checks (DisplayID-only panels).
+	bool hdr_force;
 };
 
 typedef struct {
@@ -3398,6 +3404,10 @@ bool apply_rule_to_state(Monitor *m, const ConfigMonitorRule *rule,
 	m->vrr_global_enable = rule->vrr >= 0 ? rule->vrr : 0;
 	m->hdr_enable = rule->hdr >= 0 ? rule->hdr : 0;
 	m->prefer_disable = rule->disable >= 0 ? rule->disable : 0;
+	m->hdr_min_lum = rule->hdr_min_lum;
+	m->hdr_max_lum = rule->hdr_max_lum;
+	m->hdr_max_avg_lum = rule->hdr_max_avg_lum;
+	m->hdr_force = rule->hdr_force >= 0 ? rule->hdr_force : 0;
 
 	if (rule->width > 0 && rule->height > 0 && rule->refresh > 0) {
 		struct wlr_output_mode *internal_mode = get_nearest_output_mode(
@@ -3456,6 +3466,10 @@ void createmon(struct wl_listener *listener, void *data) {
 	m->hdr_enable = false;
 	m->prefer_disable = false;
 	m->is_hdr_enabling = false;
+	m->hdr_min_lum = 0.0f;
+	m->hdr_max_lum = 0.0f;
+	m->hdr_max_avg_lum = 0.0f;
+	m->hdr_force = false;
 
 	m->wlr_output = wlr_output;
 	m->wlr_output->data = m;


### PR DESCRIPTION
Three related HDR changes. Everything below was measured on hardware — a Samsung ATNA40CU05-0 OLED (internal, amdgpu) and an RTK ZEUSLAP TYPEC over USB-C — under wlroots 0.20 with the Vulkan renderer. Single commit, `format.sh` applied.

Targets `wl-only` since that is where HDR lives.

## 1. Mastering display metadata

`output_enable_hdr()` fills only `.primaries` and `.transfer_function` of `wlr_output_image_description`. The other four fields stay zero with a designated initializer, so the panel receives an HDR infoframe with 0.0 primaries and zero luminance in the mastering block, and has to guess how to tone-map.

wlroots does not expose the EDID luminances — `wlr_output` only carries `supported_primaries` and `supported_transfer_functions` — so the values come from `monitorrule` rather than a second EDID parse:

| key | meaning |
| :--- | :--- |
| `hdr_min_lum` | mastering minimum luminance, cd/m² |
| `hdr_max_lum` | mastering peak, also sent as `max_cll` |
| `hdr_max_avg_lum` | `max_fall` |
| `hdr_force` | enable HDR even when the EDID does not advertise BT.2020/PQ |

```ini
monitorrule=name:eDP-1,...,hdr:1,hdr_max_lum:616.884,hdr_max_avg_lum:400
```

Leaving them unset leaves the fields at zero, so **existing configs behave exactly as before**.

`hdr_force` is for panels that declare HDR only inside a **DisplayID 2.0** extension, with the CTA-861 blocks nested in a `0x81` container. That is legal EDID 1.4, but libdisplay-info`s CTA path never descends into it, so `supported_primaries` comes back empty and `hdr:1` is silently dropped on hardware that drives PQ fine. It skips those two EDID-derived checks only — the `output_color_transform` check stays, since that is a real renderer capability and no config key should be able to fake it.

## 2. togglehdr

```
togglehdr[,on|off|toggle][,<monitor name>|all]
```

The runtime equivalent of sway`s `output <name> hdr on|off|toggle`. HDR could only be set from `monitorrule`, so changing it meant a config reload that also re-applies mode, scale, position and transform on every output.

With `all`, toggle takes **one** decision for every output — if anything is on, everything goes off — instead of flipping each monitor against its own state, which would leave a multi-monitor desk half on and half off and swap the halves on the next press. Outputs that cannot do HDR are skipped by the existing `output_supports_hdr()` check, which already runs before any state is mutated.

Two details worth flagging for review: the commit is forced, because `mango_scene_output_commit()` returns early when `wlr_scene_output_needs_frame()` is false and a still screen would otherwise swallow the change; and `wlr_output_state.allow_reconfiguration` must be set, or wlroots refuses the commit outright.

## 3. Damage the whole output when the image description changes

wlroots calls `scene_output_damage_whole()` for a geometry, transform, scale or rendered-gamma-LUT change — but **not** for an image description change (same call sites in 0.20.2 and master). Switching between PQ/BT.2020 and sRGB changes how every pixel has to be encoded, so anything left undamaged keeps the luminance mapping it had when last drawn. On a static desktop that is most of the screen, and the result is flat rectangles at the wrong brightness that survive further toggles.

Ruled out as a gamma problem by control: with the gamma LUT at 1.0, the daemon killed and no `zwlr_gamma_control_v1` in existence at all, the artefact still appeared.

Filling the damage ring is enough and uses only public API — `wlr_scene.c` derives the re-rendered region from `wlr_damage_ring_rotate_buffer()`. The scene also unions into `pending_commit_damage`, but that is private and only feeds the damage rectangle of the DRM commit, and a reconfiguration scans out the whole frame regardless.

## Measured result

Two panels, each fed from its own EDID:

```
eDP-1  Colorspace 9 | eotf 2 | bpc 10 | mastering 616 | max_cll 616 | max_fall 400
DP-2   Colorspace 9 | eotf 2 |          mastering 417 | max_cll 417 | max_fall 417
```

Both were `0/0/0` before. The second one also works across a multi-GPU boundary — rendered on the AMD iGPU, scanned out on a connector belonging to the discrete NVIDIA GPU.