### PR TITLE
fix(guix): remove temporary scenefx override

### DIFF
--- a/mangowm.scm
+++ b/mangowm.scm
@@ -61,7 +61,7 @@
                   pixman
                   xcb-util-wm
                   wlroots-0.20
-                  scenefx-0.5))
+                  scenefx))
     (native-inputs (list pkg-config wayland-protocols))
     (home-page "https://github.com/mangowm/mango")
     (synopsis "Wayland compositor based on wlroots and scenefx")
@@ -71,23 +71,6 @@ built on dwl — crafted for speed, flexibility, and a customizable desktop expe
     (license (list license:gpl3 ;mangowm itself, dwl
                    license:expat ;dwm, sway, wlroots
                    license:cc0)))) ;tinywl
-
-(define-public scenefx-0.5
-  (package
-    (inherit scenefx)
-    (name "scenefx")
-    (version "0.5")
-    (source (origin
-              (method git-fetch)
-              (uri (git-reference
-                     (url "https://github.com/wlrfx/scenefx")
-                     (commit version)))
-              (file-name (git-file-name name version))
-              (sha256
-               (base32
-                "0klxy73125lp9jab8qghh4v6di91l3y2rgan4m4lhv5flwdwnj5x"))))
-    (inputs (modify-inputs (package-inputs scenefx)
-              (replace "wlroots" wlroots-0.20)))))
 
 (define-deprecated-package mangowc
   mangowm-git)


### PR DESCRIPTION
guix now provides scenefx 0.5 (https://codeberg.org/guix/guix/pulls/10062)

we can now remove temp package override that was added before

follow-up to #1185