### PR TITLE
feat: Add way to control all outer gap individualy

### DIFF
--- a/assets/config.conf
+++ b/assets/config.conf
@@ -123,8 +123,10 @@ mouse_natural_scrolling=0
 # Appearance
 gappih=5
 gappiv=5
-gappoh=10
-gappov=10
+gappol=10
+gappor=10
+gappot=10
+gappob=10
 scratchpad_width_ratio=0.8
 scratchpad_height_ratio=0.9
 borderpx=4

--- a/docs/visuals/theming.md
+++ b/docs/visuals/theming.md
@@ -12,8 +12,12 @@ Control the sizing of window borders and gaps.
 | `borderpx` | `4` | Border width in pixels. |
 | `gappih` | `5` | Horizontal inner gap (between windows). |
 | `gappiv` | `5` | Vertical inner gap. |
-| `gappoh` | `10` | Horizontal outer gap (between windows and screen edges). |
-| `gappov` | `10` | Vertical outer gap. |
+| `gappot` | `10` | Outer gap, top edge. |
+| `gappor` | `10` | Outer gap, right edge. |
+| `gappob` | `10` | Outer gap, bottom edge. |
+| `gappol` | `10` | Outer gap, left edge. |
+
+> **Tip:** For backward compatibility, `gappoh` sets both `gappol` and `gappor`, and `gappov` sets both `gappot` and `gappob`. If you mix legacy and directional keys, the last one in the file wins.
 
 ## Colors
 

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -373,8 +373,10 @@ typedef struct {
 	int32_t smartgaps;
 	uint32_t gappih;
 	uint32_t gappiv;
-	uint32_t gappoh;
-	uint32_t gappov;
+	uint32_t gappol;
+	uint32_t gappor;
+	uint32_t gappot;
+	uint32_t gappob;
 	uint32_t borderpx;
 	uint32_t group_bar_height;
 	float scratchpad_width_ratio;
@@ -2116,10 +2118,24 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 		config->gappih = atoi(value);
 	} else if (strcmp(key, "gappiv") == 0) {
 		config->gappiv = atoi(value);
+	} else if (strcmp(key, "gappol") == 0) {
+		config->gappol = atoi(value);
+	} else if (strcmp(key, "gappor") == 0) {
+		config->gappor = atoi(value);
+	} else if (strcmp(key, "gappot") == 0) {
+		config->gappot = atoi(value);
+	} else if (strcmp(key, "gappob") == 0) {
+		config->gappob = atoi(value);
 	} else if (strcmp(key, "gappoh") == 0) {
-		config->gappoh = atoi(value);
+		/* backward compat: sets both left and right outer gaps */
+		int32_t v = atoi(value);
+		config->gappol = v;
+		config->gappor = v;
 	} else if (strcmp(key, "gappov") == 0) {
-		config->gappov = atoi(value);
+		/* backward compat: sets both top and bottom outer gaps */
+		int32_t v = atoi(value);
+		config->gappot = v;
+		config->gappob = v;
 	} else if (strcmp(key, "scratchpad_width_ratio") == 0) {
 		config->scratchpad_width_ratio = atof(value);
 	} else if (strcmp(key, "scratchpad_height_ratio") == 0) {
@@ -4063,8 +4079,10 @@ void override_config(void) {
 		CLAMP_FLOAT(config.trackpad_scroll_factor, 0.1f, 10.0f);
 	config.gappih = CLAMP_INT(config.gappih, 0, 1000);
 	config.gappiv = CLAMP_INT(config.gappiv, 0, 1000);
-	config.gappoh = CLAMP_INT(config.gappoh, 0, 1000);
-	config.gappov = CLAMP_INT(config.gappov, 0, 1000);
+	config.gappol = CLAMP_INT(config.gappol, 0, 1000);
+	config.gappor = CLAMP_INT(config.gappor, 0, 1000);
+	config.gappot = CLAMP_INT(config.gappot, 0, 1000);
+	config.gappob = CLAMP_INT(config.gappob, 0, 1000);
 	config.scratchpad_width_ratio =
 		CLAMP_FLOAT(config.scratchpad_width_ratio, 0.1f, 1.0f);
 	config.scratchpad_height_ratio =
@@ -4165,8 +4183,10 @@ void set_value_default() {
 	config.sloppyfocus = 1;
 	config.gappih = 5;
 	config.gappiv = 5;
-	config.gappoh = 10;
-	config.gappov = 10;
+	config.gappol = 10;
+	config.gappor = 10;
+	config.gappot = 10;
+	config.gappob = 10;
 	config.scratchpad_width_ratio = 0.8f;
 	config.scratchpad_height_ratio = 0.9f;
 
@@ -4705,8 +4725,10 @@ void reapply_master(void) {
 			m->pertag->mfacts[i] = config.default_mfact;
 			m->gappih = config.gappih;
 			m->gappiv = config.gappiv;
-			m->gappoh = config.gappoh;
-			m->gappov = config.gappov;
+			m->gappol = config.gappol;
+			m->gappor = config.gappor;
+			m->gappot = config.gappot;
+			m->gappob = config.gappob;
 		}
 	}
 }

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -87,7 +87,8 @@ void destroy_all_virtual_output(const Arg *arg) {
 }
 
 void defaultgaps(const Arg *arg) {
-	setgaps(config.gappoh, config.gappov, config.gappih, config.gappiv);
+	setgaps(config.gappol, config.gappor, config.gappot, config.gappob,
+			config.gappih, config.gappiv);
 	return;
 }
 
@@ -424,7 +425,8 @@ void incnmaster(const Arg *arg) {
 void incgaps(const Arg *arg) {
 	if (!selmon)
 		return;
-	setgaps(selmon->gappoh + arg->i, selmon->gappov + arg->i,
+	setgaps(selmon->gappol + arg->i, selmon->gappor + arg->i,
+			selmon->gappot + arg->i, selmon->gappob + arg->i,
 			selmon->gappih + arg->i, selmon->gappiv + arg->i);
 	return;
 }
@@ -432,15 +434,16 @@ void incgaps(const Arg *arg) {
 void incigaps(const Arg *arg) {
 	if (!selmon)
 		return;
-	setgaps(selmon->gappoh, selmon->gappov, selmon->gappih + arg->i,
-			selmon->gappiv + arg->i);
+	setgaps(selmon->gappol, selmon->gappor, selmon->gappot, selmon->gappob,
+			selmon->gappih + arg->i, selmon->gappiv + arg->i);
 	return;
 }
 
 void incogaps(const Arg *arg) {
 	if (!selmon)
 		return;
-	setgaps(selmon->gappoh + arg->i, selmon->gappov + arg->i, selmon->gappih,
+	setgaps(selmon->gappol + arg->i, selmon->gappor + arg->i,
+			selmon->gappot + arg->i, selmon->gappob + arg->i, selmon->gappih,
 			selmon->gappiv);
 	return;
 }
@@ -448,32 +451,32 @@ void incogaps(const Arg *arg) {
 void incihgaps(const Arg *arg) {
 	if (!selmon)
 		return;
-	setgaps(selmon->gappoh, selmon->gappov, selmon->gappih + arg->i,
-			selmon->gappiv);
+	setgaps(selmon->gappol, selmon->gappor, selmon->gappot, selmon->gappob,
+			selmon->gappih + arg->i, selmon->gappiv);
 	return;
 }
 
 void incivgaps(const Arg *arg) {
 	if (!selmon)
 		return;
-	setgaps(selmon->gappoh, selmon->gappov, selmon->gappih,
-			selmon->gappiv + arg->i);
+	setgaps(selmon->gappol, selmon->gappor, selmon->gappot, selmon->gappob,
+			selmon->gappih, selmon->gappiv + arg->i);
 	return;
 }
 
 void incohgaps(const Arg *arg) {
 	if (!selmon)
 		return;
-	setgaps(selmon->gappoh + arg->i, selmon->gappov, selmon->gappih,
-			selmon->gappiv);
+	setgaps(selmon->gappol + arg->i, selmon->gappor + arg->i, selmon->gappot,
+			selmon->gappob, selmon->gappih, selmon->gappiv);
 	return;
 }
 
 void incovgaps(const Arg *arg) {
 	if (!selmon)
 		return;
-	setgaps(selmon->gappoh, selmon->gappov + arg->i, selmon->gappih,
-			selmon->gappiv);
+	setgaps(selmon->gappol, selmon->gappor, selmon->gappot + arg->i,
+			selmon->gappob + arg->i, selmon->gappih, selmon->gappiv);
 	return;
 }
 
@@ -903,7 +906,7 @@ void smartmovewin(const Arg *arg) {
 		}
 
 		ny = tar == -99999 ? ny : tar;
-		ny = MANGO_MAX(ny, c->mon->w.y + c->mon->gappov);
+		ny = MANGO_MAX(ny, c->mon->w.y + c->mon->gappot);
 		break;
 	case DOWN:
 		tar = 99999;
@@ -923,7 +926,7 @@ void smartmovewin(const Arg *arg) {
 		}
 		ny = tar == 99999 ? ny : tar;
 		ny = MANGO_MIN(ny, c->mon->w.y + c->mon->w.height - c->geom.height -
-							   c->mon->gappov);
+							   c->mon->gappob);
 		break;
 	case LEFT:
 		tar = -99999;
@@ -943,7 +946,7 @@ void smartmovewin(const Arg *arg) {
 		}
 
 		nx = tar == -99999 ? nx : tar;
-		nx = MANGO_MAX(nx, c->mon->w.x + c->mon->gappoh);
+		nx = MANGO_MAX(nx, c->mon->w.x + c->mon->gappol);
 		break;
 	case RIGHT:
 		tar = 99999;
@@ -962,7 +965,7 @@ void smartmovewin(const Arg *arg) {
 		}
 		nx = tar == 99999 ? nx : tar;
 		nx = MANGO_MIN(nx, c->mon->w.x + c->mon->w.width - c->geom.width -
-							   c->mon->gappoh);
+							   c->mon->gappor);
 		break;
 	}
 
@@ -1009,8 +1012,8 @@ void smartresizewin(const Arg *arg) {
 			};
 		}
 		nh = tar == -99999 ? nh : tar;
-		if (c->geom.y + nh + config.gappov > selmon->w.y + selmon->w.height)
-			nh = selmon->w.y + selmon->w.height - c->geom.y - config.gappov;
+		if (c->geom.y + nh + config.gappob > selmon->w.y + selmon->w.height)
+			nh = selmon->w.y + selmon->w.height - c->geom.y - config.gappob;
 		break;
 	case LEFT:
 		nw -= selmon->w.width / 16;
@@ -1033,8 +1036,8 @@ void smartresizewin(const Arg *arg) {
 		}
 
 		nw = tar == 99999 ? nw : tar;
-		if (c->geom.x + nw + config.gappoh > selmon->w.x + selmon->w.width)
-			nw = selmon->w.x + selmon->w.width - c->geom.x - config.gappoh;
+		if (c->geom.x + nw + config.gappor > selmon->w.x + selmon->w.width)
+			nw = selmon->w.x + selmon->w.width - c->geom.x - config.gappor;
 		break;
 	}
 

--- a/src/fetch/client.h
+++ b/src/fetch/client.h
@@ -105,7 +105,7 @@ setclient_coordinate_center(Client *c, Monitor *tm, struct wlr_box geom,
 	tempbox.height = geom.height;
 
 	if (offsetx != 0) {
-		len = (m->w.width - tempbox.width - 2 * m->gappoh) / 2;
+		len = (m->w.width - tempbox.width - m->gappol - m->gappor) / 2;
 		offset = len * (offsetx / 100.0);
 		tempbox.x += offset;
 
@@ -118,7 +118,7 @@ setclient_coordinate_center(Client *c, Monitor *tm, struct wlr_box geom,
 		}
 	}
 	if (offsety != 0) {
-		len = (m->w.height - tempbox.height - 2 * m->gappov) / 2;
+		len = (m->w.height - tempbox.height - m->gappot - m->gappob) / 2;
 		offset = len * (offsety / 100.0);
 		tempbox.y += offset;
 

--- a/src/layout/dwindle.h
+++ b/src/layout/dwindle.h
@@ -423,14 +423,16 @@ static void dwindle_resize_client(Monitor *m, Client *c) {
 	int32_t n = m->visible_tiling_clients;
 	int32_t gap_ih = enablegaps ? m->gappih : 0;
 	int32_t gap_iv = enablegaps ? m->gappiv : 0;
-	int32_t gap_oh = enablegaps ? m->gappoh : 0;
-	int32_t gap_ov = enablegaps ? m->gappov : 0;
+	int32_t gap_ol = enablegaps ? m->gappol : 0;
+	int32_t gap_or = enablegaps ? m->gappor : 0;
+	int32_t gap_ot = enablegaps ? m->gappot : 0;
+	int32_t gap_ob = enablegaps ? m->gappob : 0;
 	if (config.smartgaps && n == 1)
-		gap_ih = gap_iv = gap_oh = gap_ov = 0;
+		gap_ih = gap_iv = gap_ol = gap_or = gap_ot = gap_ob = 0;
 
-	dwindle_assign(m->pertag->dwindle_root[tag], m->w.x + gap_oh,
-				   m->w.y + gap_ov, m->w.width - 2 * gap_oh,
-				   m->w.height - 2 * gap_ov, gap_ih, gap_iv);
+	dwindle_assign(m->pertag->dwindle_root[tag], m->w.x + gap_ol,
+				   m->w.y + gap_ot, m->w.width - gap_ol - gap_or,
+				   m->w.height - gap_ot - gap_ob, gap_ih, gap_iv);
 }
 
 static void dwindle_resize_client_step(Monitor *m, Client *c, int32_t dx,
@@ -472,14 +474,16 @@ static void dwindle_resize_client_step(Monitor *m, Client *c, int32_t dx,
 	int32_t n_clients = m->visible_tiling_clients;
 	int32_t gap_ih = enablegaps ? m->gappih : 0;
 	int32_t gap_iv = enablegaps ? m->gappiv : 0;
-	int32_t gap_oh = enablegaps ? m->gappoh : 0;
-	int32_t gap_ov = enablegaps ? m->gappov : 0;
+	int32_t gap_ol = enablegaps ? m->gappol : 0;
+	int32_t gap_or = enablegaps ? m->gappor : 0;
+	int32_t gap_ot = enablegaps ? m->gappot : 0;
+	int32_t gap_ob = enablegaps ? m->gappob : 0;
 	if (config.smartgaps && n_clients == 1)
-		gap_ih = gap_iv = gap_oh = gap_ov = 0;
+		gap_ih = gap_iv = gap_ol = gap_or = gap_ot = gap_ob = 0;
 
-	dwindle_assign(m->pertag->dwindle_root[tag], m->w.x + gap_oh,
-				   m->w.y + gap_ov, m->w.width - 2 * gap_oh,
-				   m->w.height - 2 * gap_ov, gap_ih, gap_iv);
+	dwindle_assign(m->pertag->dwindle_root[tag], m->w.x + gap_ol,
+				   m->w.y + gap_ot, m->w.width - gap_ol - gap_or,
+				   m->w.height - gap_ot - gap_ob, gap_ih, gap_iv);
 }
 
 static void dwindle_remove_client(Client *c) {
@@ -660,14 +664,16 @@ void dwindle(Monitor *m) {
 
 	int32_t gap_ih = enablegaps ? m->gappih : 0;
 	int32_t gap_iv = enablegaps ? m->gappiv : 0;
-	int32_t gap_oh = enablegaps ? m->gappoh : 0;
-	int32_t gap_ov = enablegaps ? m->gappov : 0;
+	int32_t gap_ol = enablegaps ? m->gappol : 0;
+	int32_t gap_or = enablegaps ? m->gappor : 0;
+	int32_t gap_ot = enablegaps ? m->gappot : 0;
+	int32_t gap_ob = enablegaps ? m->gappob : 0;
 	if (config.smartgaps && n == 1)
-		gap_ih = gap_iv = gap_oh = gap_ov = 0;
+		gap_ih = gap_iv = gap_ol = gap_or = gap_ot = gap_ob = 0;
 
-	dwindle_assign(*root, m->w.x + gap_oh, m->w.y + gap_ov,
-				   m->w.width - 2 * gap_oh, m->w.height - 2 * gap_ov, gap_ih,
-				   gap_iv);
+	dwindle_assign(*root, m->w.x + gap_ol, m->w.y + gap_ot,
+				   m->w.width - gap_ol - gap_or, m->w.height - gap_ot - gap_ob,
+				   gap_ih, gap_iv);
 
 	free(vis);
 	free(leaves);

--- a/src/layout/horizontal.h
+++ b/src/layout/horizontal.h
@@ -16,8 +16,10 @@ void tile(Monitor *m) {
 
 	int32_t cur_gappiv = enablegaps ? m->gappiv : 0;
 	int32_t cur_gappih = enablegaps ? m->gappih : 0;
-	int32_t cur_gappov = enablegaps ? m->gappov : 0;
-	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;
+	int32_t cur_gappol = enablegaps ? m->gappol : 0;
+	int32_t cur_gappor = enablegaps ? m->gappor : 0;
+	int32_t cur_gappot = enablegaps ? m->gappot : 0;
+	int32_t cur_gappob = enablegaps ? m->gappob : 0;
 
 	cur_gappiv = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
@@ -25,12 +27,18 @@ void tile(Monitor *m) {
 	cur_gappih = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
 					 : cur_gappih;
-	cur_gappov = config.smartgaps && m->visible_fake_tiling_clients == 1
+	cur_gappol = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
-					 : cur_gappov;
-	cur_gappoh = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 : cur_gappol;
+	cur_gappor = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
-					 : cur_gappoh;
+					 : cur_gappor;
+	cur_gappot = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappot;
+	cur_gappob = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappob;
 
 	wl_list_for_each(fc, &clients, link) {
 		if (VISIBLEON(fc, m) && ISFAKETILED(fc))
@@ -45,17 +53,17 @@ void tile(Monitor *m) {
 				 ? (m->w.width + cur_gappih * ie) * mfact
 				 : 0;
 	else
-		mw = m->w.width - 2 * cur_gappoh + cur_gappih * ie;
+		mw = m->w.width - cur_gappol - cur_gappor + cur_gappih * ie;
 
 	i = 0;
-	my = ty = cur_gappov;
+	my = ty = cur_gappot;
 
-	int32_t master_surplus_height =
-		(m->w.height - 2 * cur_gappov - cur_gappiv * ie * (master_num - 1));
+	int32_t master_surplus_height = (m->w.height - cur_gappot - cur_gappob -
+									 cur_gappiv * ie * (master_num - 1));
 	float master_surplus_ratio = 1.0;
 
-	int32_t slave_surplus_height =
-		(m->w.height - 2 * cur_gappov - cur_gappiv * ie * (stack_num - 1));
+	int32_t slave_surplus_height = (m->w.height - cur_gappot - cur_gappob -
+									cur_gappiv * ie * (stack_num - 1));
 	float slave_surplus_ratio = 1.0;
 
 	wl_list_for_each(c, &clients, link) {
@@ -71,15 +79,15 @@ void tile(Monitor *m) {
 					master_surplus_ratio - c->master_inner_per;
 				c->master_mfact_per = mfact;
 			} else {
-				h = (m->w.height - my - cur_gappov -
+				h = (m->w.height - my - cur_gappob -
 					 cur_gappiv * ie * (r - 1)) /
 					r;
-				c->master_inner_per = h / (m->w.height - my - cur_gappov -
+				c->master_inner_per = h / (m->w.height - my - cur_gappob -
 										   cur_gappiv * ie * (r - 1));
 				c->master_mfact_per = mfact;
 			}
 			client_tile_resize(c,
-							   (struct wlr_box){.x = m->w.x + cur_gappoh,
+							   (struct wlr_box){.x = m->w.x + cur_gappol,
 												.y = m->w.y + my,
 												.width = mw - cur_gappih * ie,
 												.height = h},
@@ -94,19 +102,20 @@ void tile(Monitor *m) {
 				slave_surplus_ratio = slave_surplus_ratio - c->stack_inner_per;
 				c->master_mfact_per = mfact;
 			} else {
-				h = (m->w.height - ty - cur_gappov -
+				h = (m->w.height - ty - cur_gappob -
 					 cur_gappiv * ie * (r - 1)) /
 					r;
-				c->stack_inner_per = h / (m->w.height - ty - cur_gappov -
+				c->stack_inner_per = h / (m->w.height - ty - cur_gappob -
 										  cur_gappiv * ie * (r - 1));
 				c->master_mfact_per = mfact;
 			}
 
 			client_tile_resize(
 				c,
-				(struct wlr_box){.x = m->w.x + mw + cur_gappoh,
+				(struct wlr_box){.x = m->w.x + mw + cur_gappol,
 								 .y = m->w.y + ty,
-								 .width = m->w.width - mw - 2 * cur_gappoh,
+								 .width =
+									 m->w.width - mw - cur_gappol - cur_gappor,
 								 .height = h},
 				0);
 			ty += h + cur_gappiv * ie; // 使用理论高度累加
@@ -133,8 +142,10 @@ void right_tile(Monitor *m) {
 
 	int32_t cur_gappiv = enablegaps ? m->gappiv : 0;
 	int32_t cur_gappih = enablegaps ? m->gappih : 0;
-	int32_t cur_gappov = enablegaps ? m->gappov : 0;
-	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;
+	int32_t cur_gappol = enablegaps ? m->gappol : 0;
+	int32_t cur_gappor = enablegaps ? m->gappor : 0;
+	int32_t cur_gappot = enablegaps ? m->gappot : 0;
+	int32_t cur_gappob = enablegaps ? m->gappob : 0;
 
 	cur_gappiv = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
@@ -142,12 +153,18 @@ void right_tile(Monitor *m) {
 	cur_gappih = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
 					 : cur_gappih;
-	cur_gappov = config.smartgaps && m->visible_fake_tiling_clients == 1
+	cur_gappol = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
-					 : cur_gappov;
-	cur_gappoh = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 : cur_gappol;
+	cur_gappor = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
-					 : cur_gappoh;
+					 : cur_gappor;
+	cur_gappot = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappot;
+	cur_gappob = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappob;
 
 	wl_list_for_each(fc, &clients, link) {
 		if (VISIBLEON(fc, m) && ISFAKETILED(fc))
@@ -162,17 +179,17 @@ void right_tile(Monitor *m) {
 				 ? (m->w.width + cur_gappih * ie) * mfact
 				 : 0;
 	else
-		mw = m->w.width - 2 * cur_gappoh + cur_gappih * ie;
+		mw = m->w.width - cur_gappol - cur_gappor + cur_gappih * ie;
 
 	i = 0;
-	my = ty = cur_gappov;
+	my = ty = cur_gappot;
 
-	int32_t master_surplus_height =
-		(m->w.height - 2 * cur_gappov - cur_gappiv * ie * (master_num - 1));
+	int32_t master_surplus_height = (m->w.height - cur_gappot - cur_gappob -
+									 cur_gappiv * ie * (master_num - 1));
 	float master_surplus_ratio = 1.0;
 
-	int32_t slave_surplus_height =
-		(m->w.height - 2 * cur_gappov - cur_gappiv * ie * (stack_num - 1));
+	int32_t slave_surplus_height = (m->w.height - cur_gappot - cur_gappob -
+									cur_gappiv * ie * (stack_num - 1));
 	float slave_surplus_ratio = 1.0;
 
 	wl_list_for_each(c, &clients, link) {
@@ -188,16 +205,16 @@ void right_tile(Monitor *m) {
 					master_surplus_ratio - c->master_inner_per;
 				c->master_mfact_per = mfact;
 			} else {
-				h = (m->w.height - my - cur_gappov -
+				h = (m->w.height - my - cur_gappob -
 					 cur_gappiv * ie * (r - 1)) /
 					r;
-				c->master_inner_per = h / (m->w.height - my - cur_gappov -
+				c->master_inner_per = h / (m->w.height - my - cur_gappob -
 										   cur_gappiv * ie * (r - 1));
 				c->master_mfact_per = mfact;
 			}
 			client_tile_resize(c,
 							   (struct wlr_box){.x = m->w.x + m->w.width - mw -
-													 cur_gappoh +
+													 cur_gappor +
 													 cur_gappih * ie,
 												.y = m->w.y + my,
 												.width = mw - cur_gappih * ie,
@@ -213,19 +230,20 @@ void right_tile(Monitor *m) {
 				slave_surplus_ratio = slave_surplus_ratio - c->stack_inner_per;
 				c->master_mfact_per = mfact;
 			} else {
-				h = (m->w.height - ty - cur_gappov -
+				h = (m->w.height - ty - cur_gappob -
 					 cur_gappiv * ie * (r - 1)) /
 					r;
-				c->stack_inner_per = h / (m->w.height - ty - cur_gappov -
+				c->stack_inner_per = h / (m->w.height - ty - cur_gappob -
 										  cur_gappiv * ie * (r - 1));
 				c->master_mfact_per = mfact;
 			}
 
 			client_tile_resize(
 				c,
-				(struct wlr_box){.x = m->w.x + cur_gappoh,
+				(struct wlr_box){.x = m->w.x + cur_gappol,
 								 .y = m->w.y + ty,
-								 .width = m->w.width - mw - 2 * cur_gappoh,
+								 .width =
+									 m->w.width - mw - cur_gappol - cur_gappor,
 								 .height = h},
 				0);
 			ty += h + cur_gappiv * ie; // 使用理论高度累加
@@ -259,8 +277,10 @@ void center_tile(Monitor *m) {
 	// 间隙参数处理
 	int32_t cur_gappiv = enablegaps ? m->gappiv : 0; // 内部垂直间隙
 	int32_t cur_gappih = enablegaps ? m->gappih : 0; // 内部水平间隙
-	int32_t cur_gappov = enablegaps ? m->gappov : 0; // 外部垂直间隙
-	int32_t cur_gappoh = enablegaps ? m->gappoh : 0; // 外部水平间隙
+	int32_t cur_gappol = enablegaps ? m->gappol : 0; // 外部左间隙
+	int32_t cur_gappor = enablegaps ? m->gappor : 0; // 外部右间隙
+	int32_t cur_gappot = enablegaps ? m->gappot : 0; // 外部上间隙
+	int32_t cur_gappob = enablegaps ? m->gappob : 0; // 外部下间隙
 
 	// 智能间隙处理
 	cur_gappiv = config.smartgaps && m->visible_fake_tiling_clients == 1
@@ -269,12 +289,18 @@ void center_tile(Monitor *m) {
 	cur_gappih = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
 					 : cur_gappih;
-	cur_gappov = config.smartgaps && m->visible_fake_tiling_clients == 1
+	cur_gappol = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
-					 : cur_gappov;
-	cur_gappoh = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 : cur_gappol;
+	cur_gappor = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
-					 : cur_gappoh;
+					 : cur_gappor;
+	cur_gappot = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappot;
+	cur_gappob = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappob;
 
 	int32_t nmasters = m->pertag->nmasters[m->pertag->curtag];
 	mfact = fc->master_mfact_per > 0.0f ? fc->master_mfact_per
@@ -282,8 +308,8 @@ void center_tile(Monitor *m) {
 
 	// 初始化区域
 	mw = m->w.width;
-	mx = cur_gappoh;
-	my = cur_gappov;
+	mx = cur_gappol;
+	my = cur_gappot;
 	tw = mw;
 
 	// 判断是否需要主区域铺满
@@ -301,61 +327,67 @@ void center_tile(Monitor *m) {
 	}
 
 	int32_t master_surplus_height =
-		(m->w.height - 2 * cur_gappov -
+		(m->w.height - cur_gappot - cur_gappob -
 		 cur_gappiv * ie * (master_num > 0 ? master_num - 1 : 0));
 	float master_surplus_ratio = 1.0;
 	int32_t init_master_surplus = master_surplus_height;
 
 	int32_t slave_left_surplus_height =
-		(m->w.height - 2 * cur_gappov -
+		(m->w.height - cur_gappot - cur_gappob -
 		 cur_gappiv * ie * (left_num > 0 ? left_num - 1 : 0));
 	float slave_left_surplus_ratio = 1.0;
 	int32_t init_slave_left_surplus = slave_left_surplus_height;
 
 	int32_t slave_right_surplus_height =
-		(m->w.height - 2 * cur_gappov -
+		(m->w.height - cur_gappot - cur_gappob -
 		 cur_gappiv * ie * (right_num > 0 ? right_num - 1 : 0));
 	float slave_right_surplus_ratio = 1.0;
 	int32_t init_slave_right_surplus = slave_right_surplus_height;
 
 	int32_t init_single_stack_surplus =
-		(m->w.height - 2 * cur_gappov -
+		(m->w.height - cur_gappot - cur_gappob -
 		 cur_gappiv * ie * (stack_num > 0 ? stack_num - 1 : 0));
 
 	if (n > nmasters || !should_overspread) {
 		// 计算主区域宽度（居中模式）
-		mw = nmasters ? (m->w.width - 2 * cur_gappoh - cur_gappih * ie) * mfact
-					  : 0;
+		mw = nmasters
+				 ? (m->w.width - cur_gappol - cur_gappor - cur_gappih * ie) *
+					   mfact
+				 : 0;
 
 		if (n - nmasters > 1) {
 			// 多个堆叠窗口：主区域居中，左右两侧各有一个堆叠区域
-			tw = (m->w.width - mw) / 2 - cur_gappoh - cur_gappih * ie;
-			mx = cur_gappoh + tw + cur_gappih * ie;
+			tw = (m->w.width - mw - cur_gappol - cur_gappor) / 2 -
+				 cur_gappih * ie;
+			mx = cur_gappol + tw + cur_gappih * ie;
 		} else if (n - nmasters == 1) {
 			// 单个堆叠窗口的处理
 			if (config.center_when_single_stack) {
 				// stack在右边，master居中，左边空着
-				tw = (m->w.width - mw) / 2 - cur_gappoh - cur_gappih * ie;
-				mx = cur_gappoh + tw + cur_gappih * ie;
+				tw = (m->w.width - mw - cur_gappol - cur_gappor) / 2 -
+				 cur_gappih * ie;
+				mx = cur_gappol + tw + cur_gappih * ie;
 			} else {
 				// stack在右边，master在左边
-				tw = m->w.width - mw - 2 * cur_gappoh - cur_gappih * ie;
-				mx = cur_gappoh;
+				tw =
+					m->w.width - mw - cur_gappol - cur_gappor - cur_gappih * ie;
+				mx = cur_gappol;
 			}
 		} else {
 			// 只有主区域窗口：居中显示
-			tw = (m->w.width - mw) / 2 - cur_gappoh - cur_gappih * ie;
-			mx = cur_gappoh + tw + cur_gappih * ie;
+			tw = (m->w.width - mw - cur_gappol - cur_gappor) / 2 -
+				 cur_gappih * ie;
+			mx = cur_gappol + tw + cur_gappih * ie;
 		}
 	} else {
 		// 主区域铺满模式（只有主区域窗口时）
-		mw = m->w.width - 2 * cur_gappoh;
-		mx = cur_gappoh;
+		mw = m->w.width - cur_gappol - cur_gappor;
+		mx = cur_gappol;
 		tw = 0;
 	}
 
-	oty = cur_gappov;
-	ety = cur_gappov;
+	oty = cur_gappot;
+	ety = cur_gappot;
 
 	i = 0;
 	wl_list_for_each(c, &clients, link) {
@@ -369,17 +401,17 @@ void center_tile(Monitor *m) {
 				h = master_surplus_height * c->master_inner_per /
 					master_surplus_ratio;
 				if (r == 1)
-					h = m->w.height - my - cur_gappov;
+					h = m->w.height - my - cur_gappob;
 				master_surplus_height = master_surplus_height - h;
 				master_surplus_ratio =
 					master_surplus_ratio - c->master_inner_per;
 				c->master_mfact_per = mfact;
 			} else {
-				h = (m->w.height - my - cur_gappov -
+				h = (m->w.height - my - cur_gappob -
 					 cur_gappiv * ie * (r - 1)) /
 					r;
 				if (r == 1)
-					h = m->w.height - my - cur_gappov;
+					h = m->w.height - my - cur_gappob;
 				c->master_inner_per =
 					init_master_surplus > 0
 						? ((float)h / (float)init_master_surplus)
@@ -404,14 +436,14 @@ void center_tile(Monitor *m) {
 				if (c->stack_inner_per > 0.0f) {
 					h = init_single_stack_surplus * c->stack_inner_per;
 					if (r == 1)
-						h = m->w.height - ety - cur_gappov;
+						h = m->w.height - ety - cur_gappob;
 					c->master_mfact_per = mfact;
 				} else {
-					h = (m->w.height - ety - cur_gappov -
+					h = (m->w.height - ety - cur_gappob -
 						 cur_gappiv * ie * (r - 1)) /
 						r;
 					if (r == 1)
-						h = m->w.height - ety - cur_gappov;
+						h = m->w.height - ety - cur_gappob;
 					c->stack_inner_per =
 						init_single_stack_surplus > 0
 							? ((float)h / (float)init_single_stack_surplus)
@@ -443,18 +475,18 @@ void center_tile(Monitor *m) {
 						h = slave_right_surplus_height * c->stack_inner_per /
 							slave_right_surplus_ratio;
 						if (r == 1)
-							h = m->w.height - ety - cur_gappov;
+							h = m->w.height - ety - cur_gappob;
 						slave_right_surplus_height =
 							slave_right_surplus_height - h;
 						slave_right_surplus_ratio =
 							slave_right_surplus_ratio - c->stack_inner_per;
 						c->master_mfact_per = mfact;
 					} else {
-						h = (m->w.height - ety - cur_gappov -
+						h = (m->w.height - ety - cur_gappob -
 							 cur_gappiv * ie * (r - 1)) /
 							r;
 						if (r == 1)
-							h = m->w.height - ety - cur_gappov;
+							h = m->w.height - ety - cur_gappob;
 						c->stack_inner_per =
 							init_slave_right_surplus > 0
 								? ((float)h / (float)init_slave_right_surplus)
@@ -477,18 +509,18 @@ void center_tile(Monitor *m) {
 						h = slave_left_surplus_height * c->stack_inner_per /
 							slave_left_surplus_ratio;
 						if (r == 1)
-							h = m->w.height - oty - cur_gappov;
+							h = m->w.height - oty - cur_gappob;
 						slave_left_surplus_height =
 							slave_left_surplus_height - h;
 						slave_left_surplus_ratio =
 							slave_left_surplus_ratio - c->stack_inner_per;
 						c->master_mfact_per = mfact;
 					} else {
-						h = (m->w.height - oty - cur_gappov -
+						h = (m->w.height - oty - cur_gappob -
 							 cur_gappiv * ie * (r - 1)) /
 							r;
 						if (r == 1)
-							h = m->w.height - oty - cur_gappov;
+							h = m->w.height - oty - cur_gappob;
 						c->stack_inner_per =
 							init_slave_left_surplus > 0
 								? ((float)h / (float)init_slave_left_surplus)
@@ -496,7 +528,7 @@ void center_tile(Monitor *m) {
 						c->master_mfact_per = mfact;
 					}
 
-					int32_t stack_x = m->w.x + cur_gappoh;
+					int32_t stack_x = m->w.x + cur_gappol;
 					client_tile_resize(c,
 									   (struct wlr_box){.x = stack_x,
 														.y = m->w.y + oty,
@@ -520,18 +552,26 @@ void deck(Monitor *m) {
 	uint32_t nmasters = m->pertag->nmasters[m->pertag->curtag];
 
 	int32_t cur_gappih = enablegaps ? m->gappih : 0;
-	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;
-	int32_t cur_gappov = enablegaps ? m->gappov : 0;
+	int32_t cur_gappol = enablegaps ? m->gappol : 0;
+	int32_t cur_gappor = enablegaps ? m->gappor : 0;
+	int32_t cur_gappot = enablegaps ? m->gappot : 0;
+	int32_t cur_gappob = enablegaps ? m->gappob : 0;
 
 	cur_gappih = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
 					 : cur_gappih;
-	cur_gappoh = config.smartgaps && m->visible_fake_tiling_clients == 1
+	cur_gappol = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
-					 : cur_gappoh;
-	cur_gappov = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 : cur_gappol;
+	cur_gappor = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
-					 : cur_gappov;
+					 : cur_gappor;
+	cur_gappot = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappot;
+	cur_gappob = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappob;
 
 	n = m->visible_fake_tiling_clients;
 
@@ -547,9 +587,10 @@ void deck(Monitor *m) {
 										: m->pertag->mfacts[m->pertag->curtag];
 
 	if (n > nmasters)
-		mw = nmasters ? round((m->w.width - 2 * cur_gappoh) * mfact) : 0;
+		mw = nmasters ? round((m->w.width - cur_gappol - cur_gappor) * mfact)
+					  : 0;
 	else
-		mw = m->w.width - 2 * cur_gappoh;
+		mw = m->w.width - cur_gappol - cur_gappor;
 
 	i = my = 0;
 	wl_list_for_each(c, &clients, link) {
@@ -557,11 +598,11 @@ void deck(Monitor *m) {
 			continue;
 		if (i < nmasters) {
 			c->master_mfact_per = mfact;
-			int32_t h = (m->w.height - 2 * cur_gappov - my) /
+			int32_t h = (m->w.height - cur_gappot - cur_gappob - my) /
 						(MANGO_MIN(n, nmasters) - i);
 			client_tile_resize(c,
-							   (struct wlr_box){.x = m->w.x + cur_gappoh,
-												.y = m->w.y + cur_gappov + my,
+							   (struct wlr_box){.x = m->w.x + cur_gappol,
+												.y = m->w.y + cur_gappot + my,
 												.width = mw,
 												.height = h},
 							   0);
@@ -571,11 +612,12 @@ void deck(Monitor *m) {
 			c->master_mfact_per = mfact;
 			client_tile_resize(
 				c,
-				(struct wlr_box){.x = m->w.x + mw + cur_gappoh + cur_gappih,
-								 .y = m->w.y + cur_gappov,
-								 .width = m->w.width - mw - 2 * cur_gappoh -
-										  cur_gappih,
-								 .height = m->w.height - 2 * cur_gappov},
+				(struct wlr_box){.x = m->w.x + mw + cur_gappol + cur_gappih,
+								 .y = m->w.y + cur_gappot,
+								 .width = m->w.width - mw - cur_gappol -
+										  cur_gappor - cur_gappih,
+								 .height =
+									 m->w.height - cur_gappot - cur_gappob},
 				0);
 			if (c == focustop(m))
 				wlr_scene_node_raise_to_top(&c->scene->node);
@@ -589,23 +631,31 @@ monocle(Monitor *m) {
 	Client *c = NULL;
 	struct wlr_box geom;
 
-	int32_t cur_gappov = enablegaps ? m->gappov : 0;
-	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;
+	int32_t cur_gappol = enablegaps ? m->gappol : 0;
+	int32_t cur_gappor = enablegaps ? m->gappor : 0;
+	int32_t cur_gappot = enablegaps ? m->gappot : 0;
+	int32_t cur_gappob = enablegaps ? m->gappob : 0;
 
-	cur_gappoh = config.smartgaps && m->visible_fake_tiling_clients == 1
+	cur_gappol = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
-					 : cur_gappoh;
-	cur_gappov = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 : cur_gappol;
+	cur_gappor = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
-					 : cur_gappov;
+					 : cur_gappor;
+	cur_gappot = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappot;
+	cur_gappob = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappob;
 
 	wl_list_for_each(c, &clients, link) {
 		if (!VISIBLEON(c, m) || !ISFAKETILED(c))
 			continue;
-		geom.x = m->w.x + cur_gappoh;
-		geom.y = m->w.y + cur_gappov;
-		geom.width = m->w.width - 2 * cur_gappoh;
-		geom.height = m->w.height - 2 * cur_gappov;
+		geom.x = m->w.x + cur_gappol;
+		geom.y = m->w.y + cur_gappot;
+		geom.width = m->w.width - cur_gappol - cur_gappor;
+		geom.height = m->w.height - cur_gappot - cur_gappob;
 		client_tile_resize(c, geom, 0);
 	}
 }
@@ -617,7 +667,10 @@ void grid(Monitor *m) {
 	int32_t cols, rows, overcols;
 	Client *c = NULL;
 	n = 0;
-	int32_t target_gappo = enablegaps ? config.gappoh : 0;
+	int32_t target_gappol = enablegaps ? config.gappol : 0;
+	int32_t target_gappor = enablegaps ? config.gappor : 0;
+	int32_t target_gappot = enablegaps ? config.gappot : 0;
+	int32_t target_gappob = enablegaps ? config.gappob : 0;
 	int32_t target_gappi = enablegaps ? config.gappih : 0;
 	float single_width_ratio = 0.9;
 	float single_height_ratio = 0.9;
@@ -635,8 +688,10 @@ void grid(Monitor *m) {
 			if (VISIBLEON(c, m) && !c->isunglobal &&
 				((m->isoverview && !client_is_x11_popup(c)) ||
 				 ISFAKETILED(c))) {
-				cw = (m->w.width - 2 * target_gappo) * single_width_ratio;
-				ch = (m->w.height - 2 * target_gappo) * single_height_ratio;
+				cw = (m->w.width - target_gappol - target_gappor) *
+					 single_width_ratio;
+				ch = (m->w.height - target_gappot - target_gappob) *
+					 single_height_ratio;
 				target_geom.x = m->w.x + (m->w.width - cw) / 2;
 				target_geom.y = m->w.y + (m->w.height - ch) / 2;
 				target_geom.width = cw;
@@ -665,9 +720,10 @@ void grid(Monitor *m) {
 		}
 
 		float sum_col = col_pers[0] + col_pers[1];
-		float avail_w = m->w.width - 2 * target_gappo - target_gappi;
-		ch =
-			(m->w.height - 2 * target_gappo) * 0.65; // 依然保持 0.65 的美观高度
+		float avail_w =
+			m->w.width - target_gappol - target_gappor - target_gappi;
+		ch = (m->w.height - target_gappot - target_gappob) *
+			 0.65; // 依然保持 0.65 的美观高度
 
 		i = 0;
 		wl_list_for_each(c, &clients, link) {
@@ -685,13 +741,13 @@ void grid(Monitor *m) {
 				cw = avail_w * (col_pers[i] / sum_col);
 
 				if (i == 0) {
-					target_geom.x = m->w.x + target_gappo;
+					target_geom.x = m->w.x + target_gappol;
 				} else if (i == 1) {
 					// 第二个窗口的 X 坐标紧跟第一个窗口后面
 					float cw0 = avail_w * (col_pers[0] / sum_col);
-					target_geom.x = m->w.x + target_gappo + cw0 + target_gappi;
+					target_geom.x = m->w.x + target_gappol + cw0 + target_gappi;
 				}
-				target_geom.y = m->w.y + (m->w.height - ch) / 2 + target_gappo;
+				target_geom.y = m->w.y + (m->w.height - ch) / 2 + target_gappot;
 				target_geom.width = cw;
 				target_geom.height = ch;
 				client_tile_resize(c, target_geom, 0);
@@ -746,8 +802,10 @@ void grid(Monitor *m) {
 	for (i = 0; i < rows; i++)
 		sum_row += row_pers[i];
 
-	float avail_w = m->w.width - 2 * target_gappo - (cols - 1) * target_gappi;
-	float avail_h = m->w.height - 2 * target_gappo - (rows - 1) * target_gappi;
+	float avail_w =
+		m->w.width - target_gappol - target_gappor - (cols - 1) * target_gappi;
+	float avail_h =
+		m->w.height - target_gappot - target_gappob - (rows - 1) * target_gappi;
 
 	// 分配位置与尺寸
 	i = 0;
@@ -766,7 +824,7 @@ void grid(Monitor *m) {
 			c->grid_row_idx = r_idx;
 
 			// X 坐标及宽度计算
-			float fl_cx = m->w.x + target_gappo;
+			float fl_cx = m->w.x + target_gappol;
 			float fl_cw = 0.0f;
 
 			if (overcols && i >= n - overcols) {
@@ -774,7 +832,8 @@ void grid(Monitor *m) {
 				for (int j = 0; j < overcols; j++)
 					over_w += avail_w * (col_pers[j] / sum_col);
 				over_w += (overcols - 1) * target_gappi;
-				float dx = (m->w.width - over_w) / 2.0f - target_gappo;
+				float dx = (m->w.width - over_w) / 2.0f -
+						   (target_gappol + target_gappor) / 2.0f;
 
 				fl_cx += dx;
 				for (int j = 0; j < c_idx; j++)
@@ -784,16 +843,16 @@ void grid(Monitor *m) {
 				for (int j = 0; j < c_idx; j++)
 					fl_cx += avail_w * (col_pers[j] / sum_col) + target_gappi;
 				fl_cw = (c_idx == cols - 1)
-							? (m->w.x + m->w.width - target_gappo - fl_cx)
+							? (m->w.x + m->w.width - target_gappor - fl_cx)
 							: avail_w * (col_pers[c_idx] / sum_col);
 			}
 
 			// Y 坐标及高度计算
-			float fl_cy = m->w.y + target_gappo;
+			float fl_cy = m->w.y + target_gappot;
 			for (int j = 0; j < r_idx; j++)
 				fl_cy += avail_h * (row_pers[j] / sum_row) + target_gappi;
 			float fl_ch = (r_idx == rows - 1)
-							  ? (m->w.y + m->w.height - target_gappo - fl_cy)
+							  ? (m->w.y + m->w.height - target_gappob - fl_cy)
 							  : avail_h * (row_pers[r_idx] / sum_row);
 
 			target_geom.x = (int32_t)fl_cx;
@@ -820,11 +879,14 @@ void fair(Monitor *m) {
 	// 获取间距配置
 	int32_t cur_gappiv = enablegaps ? m->gappiv : 0;
 	int32_t cur_gappih = enablegaps ? m->gappih : 0;
-	int32_t cur_gappov = enablegaps ? m->gappov : 0;
-	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;
+	int32_t cur_gappol = enablegaps ? m->gappol : 0;
+	int32_t cur_gappor = enablegaps ? m->gappor : 0;
+	int32_t cur_gappot = enablegaps ? m->gappot : 0;
+	int32_t cur_gappob = enablegaps ? m->gappob : 0;
 
 	if (config.smartgaps && n == 1) {
-		cur_gappiv = cur_gappih = cur_gappov = cur_gappoh = 0;
+		cur_gappiv = cur_gappih = cur_gappol = cur_gappor = cur_gappot =
+			cur_gappob = 0;
 	}
 
 	// 计算网格行列数
@@ -923,11 +985,12 @@ void fair(Monitor *m) {
 	}
 
 	// 预计算所有列的 X 坐标和宽度
-	float avail_w = m->w.width - 2 * cur_gappoh - (cols - 1) * cur_gappih;
-	float next_x = m->w.x + cur_gappoh;
+	float avail_w =
+		m->w.width - cur_gappol - cur_gappor - (cols - 1) * cur_gappih;
+	float next_x = m->w.x + cur_gappol;
 	for (i = 0; i < cols; i++) {
 		col_x[i] = next_x;
-		col_w[i] = (i == cols - 1) ? (m->w.x + m->w.width - cur_gappoh - next_x)
+		col_w[i] = (i == cols - 1) ? (m->w.x + m->w.width - cur_gappor - next_x)
 								   : (avail_w * (col_pers[i] / sum_col));
 		next_x += col_w[i] + cur_gappih;
 	}
@@ -937,12 +1000,12 @@ void fair(Monitor *m) {
 	for (i = 0; i < base_rows; i++)
 		sum_row_base += row_pers[i];
 	float avail_h_base =
-		m->w.height - 2 * cur_gappov - (base_rows - 1) * cur_gappiv;
-	float next_y = m->w.y + cur_gappov;
+		m->w.height - cur_gappot - cur_gappob - (base_rows - 1) * cur_gappiv;
+	float next_y = m->w.y + cur_gappot;
 	for (i = 0; i < base_rows; i++) {
 		row_y_base[i] = next_y;
 		row_h_base[i] = (i == base_rows - 1)
-							? (m->w.y + m->w.height - cur_gappov - next_y)
+							? (m->w.y + m->w.height - cur_gappob - next_y)
 							: (avail_h_base * (row_pers[i] / sum_row_base));
 		next_y += row_h_base[i] + cur_gappiv;
 	}
@@ -952,12 +1015,12 @@ void fair(Monitor *m) {
 		for (i = 0; i < max_rows; i++)
 			sum_row_max += row_pers[i];
 		float avail_h_max =
-			m->w.height - 2 * cur_gappov - (max_rows - 1) * cur_gappiv;
-		next_y = m->w.y + cur_gappov;
+			m->w.height - cur_gappot - cur_gappob - (max_rows - 1) * cur_gappiv;
+		next_y = m->w.y + cur_gappot;
 		for (i = 0; i < max_rows; i++) {
 			row_y_max[i] = next_y;
 			row_h_max[i] = (i == max_rows - 1)
-							   ? (m->w.y + m->w.height - cur_gappov - next_y)
+							   ? (m->w.y + m->w.height - cur_gappob - next_y)
 							   : (avail_h_max * (row_pers[i] / sum_row_max));
 			next_y += row_h_max[i] + cur_gappiv;
 		}

--- a/src/layout/scroll.h
+++ b/src/layout/scroll.h
@@ -101,18 +101,26 @@ static void sync_scroller_state_to_clients(Monitor *m, uint32_t tag) {
 void vertical_scroll_adjust_fullandmax(Client *c, struct wlr_box *target_geom) {
 	Monitor *m = c->mon;
 	int32_t cur_gappiv = enablegaps ? m->gappiv : 0;
-	int32_t cur_gappov = enablegaps ? m->gappov : 0;
-	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;
+	int32_t cur_gappol = enablegaps ? m->gappol : 0;
+	int32_t cur_gappor = enablegaps ? m->gappor : 0;
+	int32_t cur_gappot = enablegaps ? m->gappot : 0;
+	int32_t cur_gappob = enablegaps ? m->gappob : 0;
 
 	cur_gappiv = config.smartgaps && m->visible_scroll_tiling_clients == 1
 					 ? 0
 					 : cur_gappiv;
-	cur_gappov = config.smartgaps && m->visible_scroll_tiling_clients == 1
+	cur_gappol = config.smartgaps && m->visible_scroll_tiling_clients == 1
 					 ? 0
-					 : cur_gappov;
-	cur_gappoh = config.smartgaps && m->visible_scroll_tiling_clients == 1
+					 : cur_gappol;
+	cur_gappor = config.smartgaps && m->visible_scroll_tiling_clients == 1
 					 ? 0
-					 : cur_gappoh;
+					 : cur_gappor;
+	cur_gappot = config.smartgaps && m->visible_scroll_tiling_clients == 1
+					 ? 0
+					 : cur_gappot;
+	cur_gappob = config.smartgaps && m->visible_scroll_tiling_clients == 1
+					 ? 0
+					 : cur_gappob;
 
 	if (c->isfullscreen) {
 		target_geom->width = m->m.width;
@@ -122,13 +130,13 @@ void vertical_scroll_adjust_fullandmax(Client *c, struct wlr_box *target_geom) {
 	}
 
 	if (c->ismaximizescreen) {
-		target_geom->width = m->w.width - 2 * cur_gappoh;
-		target_geom->height = m->w.height - 2 * cur_gappov;
-		target_geom->x = m->w.x + cur_gappoh;
+		target_geom->width = m->w.width - cur_gappol - cur_gappor;
+		target_geom->height = m->w.height - cur_gappot - cur_gappob;
+		target_geom->x = m->w.x + cur_gappol;
 		return;
 	}
 
-	target_geom->width = m->w.width - 2 * cur_gappoh;
+	target_geom->width = m->w.width - cur_gappol - cur_gappor;
 	target_geom->x = m->w.x + (m->w.width - target_geom->width) / 2;
 }
 
@@ -145,18 +153,26 @@ void horizontal_scroll_adjust_fullandmax(Client *c,
 										 struct wlr_box *target_geom) {
 	Monitor *m = c->mon;
 	int32_t cur_gappih = enablegaps ? m->gappih : 0;
-	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;
-	int32_t cur_gappov = enablegaps ? m->gappov : 0;
+	int32_t cur_gappol = enablegaps ? m->gappol : 0;
+	int32_t cur_gappor = enablegaps ? m->gappor : 0;
+	int32_t cur_gappot = enablegaps ? m->gappot : 0;
+	int32_t cur_gappob = enablegaps ? m->gappob : 0;
 
 	cur_gappih = config.smartgaps && m->visible_scroll_tiling_clients == 1
 					 ? 0
 					 : cur_gappih;
-	cur_gappoh = config.smartgaps && m->visible_scroll_tiling_clients == 1
+	cur_gappol = config.smartgaps && m->visible_scroll_tiling_clients == 1
 					 ? 0
-					 : cur_gappoh;
-	cur_gappov = config.smartgaps && m->visible_scroll_tiling_clients == 1
+					 : cur_gappol;
+	cur_gappor = config.smartgaps && m->visible_scroll_tiling_clients == 1
 					 ? 0
-					 : cur_gappov;
+					 : cur_gappor;
+	cur_gappot = config.smartgaps && m->visible_scroll_tiling_clients == 1
+					 ? 0
+					 : cur_gappot;
+	cur_gappob = config.smartgaps && m->visible_scroll_tiling_clients == 1
+					 ? 0
+					 : cur_gappob;
 
 	if (c->isfullscreen) {
 		target_geom->height = m->m.height;
@@ -166,13 +182,13 @@ void horizontal_scroll_adjust_fullandmax(Client *c,
 	}
 
 	if (c->ismaximizescreen) {
-		target_geom->height = m->w.height - 2 * cur_gappov;
-		target_geom->width = m->w.width - 2 * cur_gappoh;
-		target_geom->y = m->w.y + cur_gappov;
+		target_geom->height = m->w.height - cur_gappot - cur_gappob;
+		target_geom->width = m->w.width - cur_gappol - cur_gappor;
+		target_geom->y = m->w.y + cur_gappot;
 		return;
 	}
 
-	target_geom->height = m->w.height - 2 * cur_gappov;
+	target_geom->height = m->w.height - cur_gappot - cur_gappob;
 	target_geom->y = m->w.y + (m->w.height - target_geom->height) / 2;
 }
 
@@ -335,11 +351,13 @@ void scroller(Monitor *m) {
 	m->visible_scroll_tiling_clients = n_heads;
 
 	int32_t cur_gappih = enablegaps ? m->gappih : 0;
-	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;
-	int32_t cur_gappov = enablegaps ? m->gappov : 0;
+	int32_t cur_gappol = enablegaps ? m->gappol : 0;
+	int32_t cur_gappor = enablegaps ? m->gappor : 0;
+	int32_t cur_gappot = enablegaps ? m->gappot : 0;
+	int32_t cur_gappob = enablegaps ? m->gappob : 0;
 	int32_t cur_gappiv = enablegaps ? m->gappiv : 0;
 	if (config.smartgaps && n_heads == 1) {
-		cur_gappih = cur_gappoh = cur_gappov = 0;
+		cur_gappih = cur_gappol = cur_gappor = cur_gappot = cur_gappob = 0;
 	}
 	int32_t max_client_width =
 		m->w.width - 2 * config.scroller_structs - cur_gappih;
@@ -353,8 +371,9 @@ void scroller(Monitor *m) {
 									  ? head->scroller_proportion_single
 									  : scroller_default_proportion_single;
 		struct wlr_box target_geom;
-		target_geom.height = m->w.height - 2 * cur_gappov;
-		target_geom.width = (m->w.width - 2 * cur_gappoh) * single_proportion;
+		target_geom.height = m->w.height - cur_gappot - cur_gappob;
+		target_geom.width =
+			(m->w.width - cur_gappol - cur_gappor) * single_proportion;
 		target_geom.x = m->w.x + (m->w.width - target_geom.width) / 2;
 		target_geom.y = m->w.y + (m->w.height - target_geom.height) / 2;
 		horizontal_check_scroller_root_inside_mon(head->client, &target_geom);
@@ -449,7 +468,7 @@ void scroller(Monitor *m) {
 		need_scroller = false;
 
 	struct wlr_box target_geom;
-	target_geom.height = m->w.height - 2 * cur_gappov;
+	target_geom.height = m->w.height - cur_gappot - cur_gappob;
 	target_geom.width =
 		max_client_width * heads[focus_index]->scroller_proportion;
 	target_geom.y = m->w.y + (m->w.height - target_geom.height) / 2;
@@ -462,7 +481,7 @@ void scroller(Monitor *m) {
 												  &target_geom);
 		arrange_stack_node(heads[focus_index], target_geom, cur_gappiv);
 	} else if (heads[focus_index]->client->ismaximizescreen) {
-		target_geom.x = m->w.x + cur_gappoh;
+		target_geom.x = m->w.x + cur_gappol;
 		horizontal_check_scroller_root_inside_mon(heads[focus_index]->client,
 												  &target_geom);
 		arrange_stack_node(heads[focus_index], target_geom, cur_gappiv);
@@ -502,7 +521,7 @@ void scroller(Monitor *m) {
 	for (int i = 1; i <= focus_index; i++) {
 		struct ScrollerStackNode *cur = heads[focus_index - i];
 		struct wlr_box left_geom;
-		left_geom.height = m->w.height - 2 * cur_gappov;
+		left_geom.height = m->w.height - cur_gappot - cur_gappob;
 		left_geom.width = max_client_width * cur->scroller_proportion;
 		horizontal_scroll_adjust_fullandmax(cur->client, &left_geom);
 		left_geom.x = heads[focus_index - i + 1]->client->geom.x - cur_gappih -
@@ -514,7 +533,7 @@ void scroller(Monitor *m) {
 	for (int i = 1; i < n_heads - focus_index; i++) {
 		struct ScrollerStackNode *cur = heads[focus_index + i];
 		struct wlr_box right_geom;
-		right_geom.height = m->w.height - 2 * cur_gappov;
+		right_geom.height = m->w.height - cur_gappot - cur_gappob;
 		right_geom.width = max_client_width * cur->scroller_proportion;
 		horizontal_scroll_adjust_fullandmax(cur->client, &right_geom);
 		right_geom.x = heads[focus_index + i - 1]->client->geom.x + cur_gappih +
@@ -576,11 +595,13 @@ void vertical_scroller(Monitor *m) {
 	m->visible_scroll_tiling_clients = n_heads;
 
 	int32_t cur_gappiv = enablegaps ? m->gappiv : 0;
-	int32_t cur_gappov = enablegaps ? m->gappov : 0;
-	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;
+	int32_t cur_gappol = enablegaps ? m->gappol : 0;
+	int32_t cur_gappor = enablegaps ? m->gappor : 0;
+	int32_t cur_gappot = enablegaps ? m->gappot : 0;
+	int32_t cur_gappob = enablegaps ? m->gappob : 0;
 	int32_t cur_gappih = enablegaps ? m->gappih : 0;
 	if (config.smartgaps && n_heads == 1) {
-		cur_gappiv = cur_gappov = cur_gappoh = 0;
+		cur_gappiv = cur_gappol = cur_gappor = cur_gappot = cur_gappob = 0;
 	}
 	int32_t max_client_height =
 		m->w.height - 2 * config.scroller_structs - cur_gappiv;
@@ -593,8 +614,9 @@ void vertical_scroller(Monitor *m) {
 									  ? head->scroller_proportion_single
 									  : scroller_default_proportion_single;
 		struct wlr_box target_geom;
-		target_geom.width = m->w.width - 2 * cur_gappoh;
-		target_geom.height = (m->w.height - 2 * cur_gappov) * single_proportion;
+		target_geom.width = m->w.width - cur_gappol - cur_gappor;
+		target_geom.height =
+			(m->w.height - cur_gappot - cur_gappob) * single_proportion;
 		target_geom.y = m->w.y + (m->w.height - target_geom.height) / 2;
 		target_geom.x = m->w.x + (m->w.width - target_geom.width) / 2;
 		vertical_check_scroller_root_inside_mon(head->client, &target_geom);
@@ -688,7 +710,7 @@ void vertical_scroller(Monitor *m) {
 		need_scroller = false;
 
 	struct wlr_box target_geom;
-	target_geom.width = m->w.width - 2 * cur_gappoh;
+	target_geom.width = m->w.width - cur_gappol - cur_gappor;
 	target_geom.height =
 		max_client_height * heads[focus_index]->scroller_proportion;
 	target_geom.x = m->w.x + (m->w.width - target_geom.width) / 2;
@@ -701,7 +723,7 @@ void vertical_scroller(Monitor *m) {
 		arrange_stack_vertical_node(heads[focus_index], target_geom,
 									cur_gappih);
 	} else if (heads[focus_index]->client->ismaximizescreen) {
-		target_geom.y = m->w.y + cur_gappov;
+		target_geom.y = m->w.y + cur_gappot;
 		vertical_check_scroller_root_inside_mon(heads[focus_index]->client,
 												&target_geom);
 		arrange_stack_vertical_node(heads[focus_index], target_geom,
@@ -748,7 +770,7 @@ void vertical_scroller(Monitor *m) {
 	for (int i = 1; i <= focus_index; i++) {
 		struct ScrollerStackNode *cur = heads[focus_index - i];
 		struct wlr_box up_geom;
-		up_geom.width = m->w.width - 2 * cur_gappoh;
+		up_geom.width = m->w.width - cur_gappol - cur_gappor;
 		up_geom.height = max_client_height * cur->scroller_proportion;
 		vertical_scroll_adjust_fullandmax(cur->client, &up_geom);
 
@@ -766,7 +788,7 @@ void vertical_scroller(Monitor *m) {
 	for (int i = 1; i < n_heads - focus_index; i++) {
 		struct ScrollerStackNode *cur = heads[focus_index + i];
 		struct wlr_box down_geom;
-		down_geom.width = m->w.width - 2 * cur_gappoh;
+		down_geom.width = m->w.width - cur_gappol - cur_gappor;
 		down_geom.height = max_client_height * cur->scroller_proportion;
 		vertical_scroll_adjust_fullandmax(cur->client, &down_geom);
 		down_geom.y = heads[focus_index + i - 1]->client->geom.y + cur_gappiv +

--- a/src/layout/vertical.h
+++ b/src/layout/vertical.h
@@ -16,17 +16,27 @@ void vertical_tile(Monitor *m) {
 
 	int32_t cur_gapih = enablegaps ? m->gappih : 0;
 	int32_t cur_gapiv = enablegaps ? m->gappiv : 0;
-	int32_t cur_gapoh = enablegaps ? m->gappoh : 0;
-	int32_t cur_gapov = enablegaps ? m->gappov : 0;
+	int32_t cur_gappol = enablegaps ? m->gappol : 0;
+	int32_t cur_gappor = enablegaps ? m->gappor : 0;
+	int32_t cur_gappot = enablegaps ? m->gappot : 0;
+	int32_t cur_gappob = enablegaps ? m->gappob : 0;
 
 	cur_gapih =
 		config.smartgaps && m->visible_fake_tiling_clients == 1 ? 0 : cur_gapih;
 	cur_gapiv =
 		config.smartgaps && m->visible_fake_tiling_clients == 1 ? 0 : cur_gapiv;
-	cur_gapoh =
-		config.smartgaps && m->visible_fake_tiling_clients == 1 ? 0 : cur_gapoh;
-	cur_gapov =
-		config.smartgaps && m->visible_fake_tiling_clients == 1 ? 0 : cur_gapov;
+	cur_gappol = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappol;
+	cur_gappor = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappor;
+	cur_gappot = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappot;
+	cur_gappob = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappob;
 
 	wl_list_for_each(fc, &clients, link) {
 		if (VISIBLEON(fc, m) && ISFAKETILED(fc))
@@ -41,17 +51,17 @@ void vertical_tile(Monitor *m) {
 				 ? (m->w.height + cur_gapiv * ie) * mfact
 				 : 0;
 	else
-		mh = m->w.height - 2 * cur_gapov + cur_gapiv * ie;
+		mh = m->w.height - cur_gappot - cur_gappob + cur_gapiv * ie;
 
 	i = 0;
-	mx = tx = cur_gapoh;
+	mx = tx = cur_gappol;
 
-	int32_t master_surplus_width =
-		(m->w.width - 2 * cur_gapoh - cur_gapih * ie * (master_num - 1));
+	int32_t master_surplus_width = (m->w.width - cur_gappol - cur_gappor -
+									cur_gapih * ie * (master_num - 1));
 	float master_surplus_ratio = 1.0;
 
-	int32_t slave_surplus_width =
-		(m->w.width - 2 * cur_gapoh - cur_gapih * ie * (stack_num - 1));
+	int32_t slave_surplus_width = (m->w.width - cur_gappol - cur_gappor -
+								   cur_gapih * ie * (stack_num - 1));
 	float slave_surplus_ratio = 1.0;
 
 	wl_list_for_each(c, &clients, link) {
@@ -75,7 +85,7 @@ void vertical_tile(Monitor *m) {
 			}
 			client_tile_resize(c,
 							   (struct wlr_box){.x = m->w.x + mx,
-												.y = m->w.y + cur_gapov,
+												.y = m->w.y + cur_gappot,
 												.width = w,
 												.height = mh - cur_gapiv * ie},
 							   0);
@@ -96,13 +106,14 @@ void vertical_tile(Monitor *m) {
 				c->master_mfact_per = mfact;
 			}
 
-			client_tile_resize(
-				c,
-				(struct wlr_box){.x = m->w.x + tx,
-								 .y = m->w.y + mh + cur_gapov,
-								 .width = w,
-								 .height = m->w.height - mh - 2 * cur_gapov},
-				0);
+			client_tile_resize(c,
+							   (struct wlr_box){.x = m->w.x + tx,
+												.y = m->w.y + mh + cur_gappot,
+												.width = w,
+												.height = m->w.height - mh -
+														  cur_gappot -
+														  cur_gappob},
+							   0);
 			tx += w + cur_gapih * ie; // 使用理论宽度累加
 		}
 		i++;
@@ -118,18 +129,26 @@ void vertical_deck(Monitor *m) {
 	uint32_t nmasters = m->pertag->nmasters[m->pertag->curtag];
 
 	int32_t cur_gappiv = enablegaps ? m->gappiv : 0;
-	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;
-	int32_t cur_gappov = enablegaps ? m->gappov : 0;
+	int32_t cur_gappol = enablegaps ? m->gappol : 0;
+	int32_t cur_gappor = enablegaps ? m->gappor : 0;
+	int32_t cur_gappot = enablegaps ? m->gappot : 0;
+	int32_t cur_gappob = enablegaps ? m->gappob : 0;
 
 	cur_gappiv = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
 					 : cur_gappiv;
-	cur_gappoh = config.smartgaps && m->visible_fake_tiling_clients == 1
+	cur_gappol = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
-					 : cur_gappoh;
-	cur_gappov = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 : cur_gappol;
+	cur_gappor = config.smartgaps && m->visible_fake_tiling_clients == 1
 					 ? 0
-					 : cur_gappov;
+					 : cur_gappor;
+	cur_gappot = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappot;
+	cur_gappob = config.smartgaps && m->visible_fake_tiling_clients == 1
+					 ? 0
+					 : cur_gappob;
 
 	n = m->visible_fake_tiling_clients;
 
@@ -145,9 +164,10 @@ void vertical_deck(Monitor *m) {
 										: m->pertag->mfacts[m->pertag->curtag];
 
 	if (n > nmasters)
-		mh = nmasters ? round((m->w.height - 2 * cur_gappov) * mfact) : 0;
+		mh = nmasters ? round((m->w.height - cur_gappot - cur_gappob) * mfact)
+					  : 0;
 	else
-		mh = m->w.height - 2 * cur_gappov;
+		mh = m->w.height - cur_gappot - cur_gappob;
 
 	i = mx = 0;
 	wl_list_for_each(c, &clients, link) {
@@ -155,11 +175,11 @@ void vertical_deck(Monitor *m) {
 			continue;
 		if (i < nmasters) {
 			c->master_mfact_per = mfact;
-			int32_t w = (m->w.width - 2 * cur_gappoh - mx) /
+			int32_t w = (m->w.width - cur_gappol - cur_gappor - mx) /
 						(MANGO_MIN(n, nmasters) - i);
 			client_tile_resize(c,
-							   (struct wlr_box){.x = m->w.x + cur_gappoh + mx,
-												.y = m->w.y + cur_gappov,
+							   (struct wlr_box){.x = m->w.x + cur_gappol + mx,
+												.y = m->w.y + cur_gappot,
 												.width = w,
 												.height = mh},
 							   0);
@@ -168,11 +188,11 @@ void vertical_deck(Monitor *m) {
 			c->master_mfact_per = mfact;
 			client_tile_resize(
 				c,
-				(struct wlr_box){.x = m->w.x + cur_gappoh,
-								 .y = m->w.y + mh + cur_gappov + cur_gappiv,
-								 .width = m->w.width - 2 * cur_gappoh,
-								 .height = m->w.height - mh - 2 * cur_gappov -
-										   cur_gappiv},
+				(struct wlr_box){.x = m->w.x + cur_gappol,
+								 .y = m->w.y + mh + cur_gappot + cur_gappiv,
+								 .width = m->w.width - cur_gappol - cur_gappor,
+								 .height = m->w.height - mh - cur_gappot -
+										   cur_gappob - cur_gappiv},
 				0);
 			if (c == focustop(m))
 				wlr_scene_node_raise_to_top(&c->scene->node);
@@ -186,7 +206,10 @@ void vertical_grid(Monitor *m) {
 	int32_t cw, ch;
 	int32_t rows, cols, overrows;
 	Client *c = NULL;
-	int32_t target_gappo = enablegaps ? config.gappov : 0;
+	int32_t target_gappol = enablegaps ? config.gappol : 0;
+	int32_t target_gappor = enablegaps ? config.gappor : 0;
+	int32_t target_gappot = enablegaps ? config.gappot : 0;
+	int32_t target_gappob = enablegaps ? config.gappob : 0;
 	int32_t target_gappi = enablegaps ? config.gappiv : 0;
 	float single_width_ratio = 0.9;
 	float single_height_ratio = 0.9;
@@ -202,8 +225,10 @@ void vertical_grid(Monitor *m) {
 				continue;
 			if (VISIBLEON(c, m) && !c->isunglobal &&
 				(!client_is_x11_popup(c) || ISFAKETILED(c))) {
-				ch = (m->w.height - 2 * target_gappo) * single_height_ratio;
-				cw = (m->w.width - 2 * target_gappo) * single_width_ratio;
+				ch = (m->w.height - target_gappot - target_gappob) *
+					 single_height_ratio;
+				cw = (m->w.width - target_gappol - target_gappor) *
+					 single_width_ratio;
 				target_geom.x = m->w.x + (m->w.width - cw) / 2;
 				target_geom.y = m->w.y + (m->w.height - ch) / 2;
 				target_geom.width = cw;
@@ -231,8 +256,10 @@ void vertical_grid(Monitor *m) {
 		}
 
 		float sum_row = row_pers[0] + row_pers[1];
-		float avail_h = m->w.height - 2 * target_gappo - target_gappi;
-		cw = (m->w.width - 2 * target_gappo) * 0.65; // 依然保持 0.65 的美观宽度
+		float avail_h =
+			m->w.height - target_gappot - target_gappob - target_gappi;
+		cw = (m->w.width - target_gappol - target_gappor) *
+			 0.65; // 依然保持 0.65 的美观宽度
 
 		i = 0;
 		wl_list_for_each(c, &clients, link) {
@@ -248,13 +275,13 @@ void vertical_grid(Monitor *m) {
 				// 根据分配的权重动态计算当前窗口的高度
 				ch = avail_h * (row_pers[i] / sum_row);
 
-				target_geom.x = m->w.x + (m->w.width - cw) / 2 + target_gappo;
+				target_geom.x = m->w.x + (m->w.width - cw) / 2 + target_gappol;
 				if (i == 0) {
-					target_geom.y = m->w.y + target_gappo;
+					target_geom.y = m->w.y + target_gappot;
 				} else if (i == 1) {
 					// 第二个窗口的 Y 坐标紧跟第一个窗口下面
 					float ch0 = avail_h * (row_pers[0] / sum_row);
-					target_geom.y = m->w.y + target_gappo + ch0 + target_gappi;
+					target_geom.y = m->w.y + target_gappot + ch0 + target_gappi;
 				}
 				target_geom.width = cw;
 				target_geom.height = ch;
@@ -307,8 +334,10 @@ void vertical_grid(Monitor *m) {
 	for (i = 0; i < rows; i++)
 		sum_row += row_pers[i];
 
-	float avail_w = m->w.width - 2 * target_gappo - (cols - 1) * target_gappi;
-	float avail_h = m->w.height - 2 * target_gappo - (rows - 1) * target_gappi;
+	float avail_w =
+		m->w.width - target_gappol - target_gappor - (cols - 1) * target_gappi;
+	float avail_h =
+		m->w.height - target_gappot - target_gappob - (rows - 1) * target_gappi;
 
 	i = 0;
 	wl_list_for_each(c, &clients, link) {
@@ -324,7 +353,7 @@ void vertical_grid(Monitor *m) {
 			c->grid_col_idx = c_idx;
 			c->grid_row_idx = r_idx;
 
-			float fl_cy = m->w.y + target_gappo;
+			float fl_cy = m->w.y + target_gappot;
 			float fl_ch = 0.0f;
 
 			if (overrows && i >= n - overrows) {
@@ -332,7 +361,8 @@ void vertical_grid(Monitor *m) {
 				for (int j = 0; j < overrows; j++)
 					over_h += avail_h * (row_pers[j] / sum_row);
 				over_h += (overrows - 1) * target_gappi;
-				float dy = (m->w.height - over_h) / 2.0f - target_gappo;
+				float dy = (m->w.height - over_h) / 2.0f -
+						   (target_gappot + target_gappob) / 2.0f;
 
 				fl_cy += dy;
 				for (int j = 0; j < r_idx; j++)
@@ -342,15 +372,15 @@ void vertical_grid(Monitor *m) {
 				for (int j = 0; j < r_idx; j++)
 					fl_cy += avail_h * (row_pers[j] / sum_row) + target_gappi;
 				fl_ch = (r_idx == rows - 1)
-							? (m->w.y + m->w.height - target_gappo - fl_cy)
+							? (m->w.y + m->w.height - target_gappob - fl_cy)
 							: avail_h * (row_pers[r_idx] / sum_row);
 			}
 
-			float fl_cx = m->w.x + target_gappo;
+			float fl_cx = m->w.x + target_gappol;
 			for (int j = 0; j < c_idx; j++)
 				fl_cx += avail_w * (col_pers[j] / sum_col) + target_gappi;
 			float fl_cw = (c_idx == cols - 1)
-							  ? (m->w.x + m->w.width - target_gappo - fl_cx)
+							  ? (m->w.x + m->w.width - target_gappor - fl_cx)
 							  : avail_w * (col_pers[c_idx] / sum_col);
 
 			target_geom.x = (int32_t)fl_cx;
@@ -376,11 +406,14 @@ void vertical_fair(Monitor *m) {
 
 	int32_t cur_gappiv = enablegaps ? m->gappiv : 0;
 	int32_t cur_gappih = enablegaps ? m->gappih : 0;
-	int32_t cur_gappov = enablegaps ? m->gappov : 0;
-	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;
+	int32_t cur_gappol = enablegaps ? m->gappol : 0;
+	int32_t cur_gappor = enablegaps ? m->gappor : 0;
+	int32_t cur_gappot = enablegaps ? m->gappot : 0;
+	int32_t cur_gappob = enablegaps ? m->gappob : 0;
 
 	if (config.smartgaps && n == 1) {
-		cur_gappiv = cur_gappih = cur_gappov = cur_gappoh = 0;
+		cur_gappiv = cur_gappih = cur_gappol = cur_gappor = cur_gappot =
+			cur_gappob = 0;
 	}
 
 	int32_t rows;
@@ -473,12 +506,13 @@ void vertical_fair(Monitor *m) {
 			col_pers[i] = 1.0f;
 	}
 
-	float avail_h = m->w.height - 2 * cur_gappov - (rows - 1) * cur_gappiv;
-	float next_y = m->w.y + cur_gappov;
+	float avail_h =
+		m->w.height - cur_gappot - cur_gappob - (rows - 1) * cur_gappiv;
+	float next_y = m->w.y + cur_gappot;
 	for (i = 0; i < rows; i++) {
 		row_y[i] = next_y;
 		row_h[i] = (i == rows - 1)
-					   ? (m->w.y + m->w.height - cur_gappov - next_y)
+					   ? (m->w.y + m->w.height - cur_gappob - next_y)
 					   : (avail_h * (row_pers[i] / sum_row));
 		next_y += row_h[i] + cur_gappiv;
 	}
@@ -487,12 +521,12 @@ void vertical_fair(Monitor *m) {
 	for (i = 0; i < base_cols; i++)
 		sum_col_base += col_pers[i];
 	float avail_w_base =
-		m->w.width - 2 * cur_gappoh - (base_cols - 1) * cur_gappih;
-	float next_x = m->w.x + cur_gappoh;
+		m->w.width - cur_gappol - cur_gappor - (base_cols - 1) * cur_gappih;
+	float next_x = m->w.x + cur_gappol;
 	for (i = 0; i < base_cols; i++) {
 		col_x_base[i] = next_x;
 		col_w_base[i] = (i == base_cols - 1)
-							? (m->w.x + m->w.width - cur_gappoh - next_x)
+							? (m->w.x + m->w.width - cur_gappor - next_x)
 							: (avail_w_base * (col_pers[i] / sum_col_base));
 		next_x += col_w_base[i] + cur_gappih;
 	}
@@ -502,12 +536,12 @@ void vertical_fair(Monitor *m) {
 		for (i = 0; i < max_cols; i++)
 			sum_col_max += col_pers[i];
 		float avail_w_max =
-			m->w.width - 2 * cur_gappoh - (max_cols - 1) * cur_gappih;
-		next_x = m->w.x + cur_gappoh;
+			m->w.width - cur_gappol - cur_gappor - (max_cols - 1) * cur_gappih;
+		next_x = m->w.x + cur_gappol;
 		for (i = 0; i < max_cols; i++) {
 			col_x_max[i] = next_x;
 			col_w_max[i] = (i == max_cols - 1)
-							   ? (m->w.x + m->w.width - cur_gappoh - next_x)
+							   ? (m->w.x + m->w.width - cur_gappor - next_x)
 							   : (avail_w_max * (col_pers[i] / sum_col_max));
 			next_x += col_w_max[i] + cur_gappih;
 		}

--- a/src/mango.c
+++ b/src/mango.c
@@ -598,8 +598,10 @@ struct Monitor {
 
 	int32_t gappih; /* horizontal gap between windows */
 	int32_t gappiv; /* vertical gap between windows */
-	int32_t gappoh; /* horizontal outer gaps */
-	int32_t gappov; /* vertical outer gaps */
+	int32_t gappol; /* outer gap left */
+	int32_t gappor; /* outer gap right */
+	int32_t gappot; /* outer gap top */
+	int32_t gappob; /* outer gap bottom */
 	Pertag *pertag;
 	uint32_t ovbk_current_tagset;
 	uint32_t ovbk_prev_tagset;
@@ -811,7 +813,8 @@ static void setfullscreen(Client *c, int32_t fullscreen, bool rearrange);
 static void setmaximizescreen(Client *c, int32_t maximizescreen,
 							  bool rearrange);
 static void reset_maximizescreen_size(Client *c);
-static void setgaps(int32_t oh, int32_t ov, int32_t ih, int32_t iv);
+static void setgaps(int32_t ol, int32_t or_, int32_t ot, int32_t ob, int32_t ih,
+					int32_t iv);
 
 static void setmon(Client *c, Monitor *m, uint32_t newtags, bool focus);
 static void setpsel(struct wl_listener *listener, void *data);
@@ -3579,8 +3582,10 @@ void createmon(struct wl_listener *listener, void *data) {
 
 	m->gappih = config.gappih;
 	m->gappiv = config.gappiv;
-	m->gappoh = config.gappoh;
-	m->gappov = config.gappov;
+	m->gappol = config.gappol;
+	m->gappor = config.gappor;
+	m->gappot = config.gappot;
+	m->gappob = config.gappob;
 	m->isoverview = 0;
 	m->sel = NULL;
 	m->is_in_hotarea = 0;
@@ -5974,13 +5979,14 @@ setfloating(Client *c, int32_t floating) {
 
 		// restore to the memeroy geom
 		if (c->float_geom.width > 0 && c->float_geom.height > 0) {
-			if (c->mon &&
-				c->float_geom.width >= c->mon->w.width - config.gappoh) {
+			if (c->mon && c->float_geom.width >=
+							  c->mon->w.width - config.gappol - config.gappor) {
 				c->float_geom.width = c->mon->w.width * 0.9;
 				window_size_outofrange = true;
 			}
-			if (c->mon &&
-				c->float_geom.height >= c->mon->w.height - config.gappov) {
+			if (c->mon && c->float_geom.height >= c->mon->w.height -
+													  config.gappot -
+													  config.gappob) {
 				c->float_geom.height = c->mon->w.height * 0.9;
 				window_size_outofrange = true;
 			}
@@ -6039,10 +6045,10 @@ setfloating(Client *c, int32_t floating) {
 
 void reset_maximizescreen_size(Client *c) {
 	struct wlr_box geom;
-	geom.x = c->mon->w.x + config.gappoh;
-	geom.y = c->mon->w.y + config.gappov;
-	geom.width = c->mon->w.width - 2 * config.gappoh;
-	geom.height = c->mon->w.height - 2 * config.gappov;
+	geom.x = c->mon->w.x + config.gappol;
+	geom.y = c->mon->w.y + config.gappot;
+	geom.width = c->mon->w.width - config.gappol - config.gappor;
+	geom.height = c->mon->w.height - config.gappot - config.gappob;
 
 	if (c->group_next || c->group_prev) {
 		geom.height -= config.group_bar_height;
@@ -6087,10 +6093,12 @@ void setmaximizescreen(Client *c, int32_t maximizescreen, bool rearrange) {
 
 		exit_scroller_stack(c);
 
-		maximizescreen_box.x = c->mon->w.x + config.gappoh;
-		maximizescreen_box.y = c->mon->w.y + config.gappov;
-		maximizescreen_box.width = c->mon->w.width - 2 * config.gappoh;
-		maximizescreen_box.height = c->mon->w.height - 2 * config.gappov;
+		maximizescreen_box.x = c->mon->w.x + config.gappol;
+		maximizescreen_box.y = c->mon->w.y + config.gappot;
+		maximizescreen_box.width =
+			c->mon->w.width - config.gappol - config.gappor;
+		maximizescreen_box.height =
+			c->mon->w.height - config.gappot - config.gappob;
 
 		if (c->group_next || c->group_prev) {
 			maximizescreen_box.height -= config.group_bar_height;
@@ -6174,9 +6182,12 @@ void setfullscreen(Client *c, int32_t fullscreen,
 		arrange(c->mon, false, false);
 }
 
-void setgaps(int32_t oh, int32_t ov, int32_t ih, int32_t iv) {
-	selmon->gappoh = MANGO_MAX(oh, 0);
-	selmon->gappov = MANGO_MAX(ov, 0);
+void setgaps(int32_t ol, int32_t or_, int32_t ot, int32_t ob, int32_t ih,
+			 int32_t iv) {
+	selmon->gappol = MANGO_MAX(ol, 0);
+	selmon->gappor = MANGO_MAX(or_, 0);
+	selmon->gappot = MANGO_MAX(ot, 0);
+	selmon->gappob = MANGO_MAX(ob, 0);
 	selmon->gappih = MANGO_MAX(ih, 0);
 	selmon->gappiv = MANGO_MAX(iv, 0);
 	arrange(selmon, false, false);


### PR DESCRIPTION
You can define a different gap on the right and on the left, same for top and bottom. Intorudce 4 new settings

| Setting | Default | Description |
| :--- | :--- | :--- |
| `gappol` | `10` | Outer gap, left edge. |
| `gappor` | `10` | Outer gap, right edge. |
| `gappot` | `10` | Outer gap, top edge. |
| `gappob` | `10` | Outer gap, bottom edge. |

For backward compatibility, `gappoh` sets both `gappol` and `gappor`, and `gappov` sets both `gappot` and `gappob`. If you mix legacy and directional keys, the last one in the file wins.


i have run `./format.sh`

I have compile and test them, they work fine, and the backward compatibility too work