### PR TITLE
feat: add new ipc command get layouts

### DIFF
--- a/mmsg/mmsg.c
+++ b/mmsg/mmsg.c
@@ -32,6 +32,7 @@ static void usage(void) {
 	printf("  get all-monitors                         List all monitors\n");
 	printf("  get all-tags                             List all tags (all "
 		   "monitors)\n");
+	printf("  get layouts                              List all available layouts\n");
 	printf(
 		"  get tags <monitor>                       List tags for a monitor\n");
 	printf("  dispatch <func>[,arg...] [client,<id>]   Call a compositor "

--- a/src/ipc/ipc.h
+++ b/src/ipc/ipc.h
@@ -233,6 +233,19 @@ static cJSON *build_monitor_tags_response(Monitor *m) {
 	return resp;
 }
 
+static cJSON *build_layouts_response(void) {
+	cJSON *arr = cJSON_CreateArray();
+	for (size_t i = 0; i < LENGTH(layouts); i++) {
+		cJSON *entry = cJSON_CreateObject();
+		cJSON_AddStringToObject(entry, "symbol", layouts[i].symbol);
+		cJSON_AddStringToObject(entry, "name", layouts[i].name);
+		cJSON_AddItemToArray(arr, entry);
+	}
+	cJSON *resp = cJSON_CreateObject();
+	cJSON_AddItemToObject(resp, "layouts", arr);
+	return resp;
+}
+
 static void send_static_json(int fd, const char *json_str) {
 	size_t len = strlen(json_str);
 	send(fd, json_str, len, 0);
@@ -367,6 +380,8 @@ static void handle_command(int client_fd, const char *cmd_raw) {
 			return;
 		}
 		resp = build_monitor_tags_response(m);
+	} else if (strcmp(cmd, "get layouts") == 0) {
+		resp = build_layouts_response();
 	} else if (strncmp(cmd, "dispatch ", 9) == 0) {
 		char *dispatch_copy = strdup(cmd_raw + 9);
 		char *out = dispatch_copy, *ptr = dispatch_copy;


### PR DESCRIPTION
Added a new ipc command, `mmsg get layouts`, which outputs all available layouts in json format:
```json
└> mmsg get layouts
{"layouts":[{"symbol":"T","name":"tile"},{"symbol":"S","name":"scroller"},{"symbol":"G","name":"grid"},{"symbol":"M","name":"monocle"},{"symbol":"K","name":"deck"},{"symbol":"CT","name":"center_tile"},{"symbol":"RT","name":"right_tile"},{"symbol":"VS","name":"vertical_scroller"},{"symbol":"VT","name":"vertical_tile"},{"symbol":"VG","name":"vertical_grid"},{"symbol":"VK","name":"vertical_deck"},{"symbol":"DW","name":"dwindle"},{"symbol":"F","name":"fair"},{"symbol":"VF","name":"vertical_fair"}]}
```

Useful if you want to develop a layout switcher menu using fuzzel/rofi/wofi, but do not want to hardcode mango's layouts in your script. For example:
```bash
layout="$(mmsg get layouts | jq -r '.layouts[] | .symbol + "\t" + .name' | fuzzel -d --mesg 'Select layout' --accept-nth=2)"
mmsg dispatch "setlayout,${layout}"
```
<img width="414" height="441" alt="image" src="https://github.com/user-attachments/assets/9458fb87-ebac-4513-86c9-9c07cbce568b" />
