### PR TITLE
feat: add spawn_on_tag dispatch

### DIFF
--- a/docs/bindings/keys.md
+++ b/docs/bindings/keys.md
@@ -183,6 +183,7 @@ It is formed by tag numbers `1`–`9`, optionally combined with `|`.
 | `spawn` | `cmd` | Execute a command. |
 | `spawn_shell` | `cmd` | Execute shell command (supports pipes `\|`). |
 | `spawn_on_empty` | `cmd, tagmask` | Open command on empty tag.Accepts a cmd string and [tagmask](/docs/bindings/keys#tag-mask-format) |
+| `spawn_on_tag` | `cmd, tagmask` | Open a shell command on the specified tag without switching view; only the first matching window is tagged. |
 | `reload_config` | - | Hot-reload configuration. |
 | `load_config_file` | `file path` | Load configuration from the specified file. Empty path resets to default config location. |
 | `quit` | - | Exit mangowm. |

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -1317,6 +1317,10 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 		func = spawn_on_empty;
 		(*arg).v = strdup(arg_value);
 		(*arg).ui = parse_tag_mask(arg_value2);
+	} else if (strcmp(func_name, "spawn_on_tag") == 0) {
+		func = spawn_on_tag;
+		(*arg).v = strdup(arg_value);
+		(*arg).ui = parse_tag_mask(arg_value2);
 	} else if (strcmp(func_name, "quit") == 0) {
 		func = quit;
 	} else if (strcmp(func_name, "create_virtual_output") == 0) {

--- a/src/dispatch/bind_declare.h
+++ b/src/dispatch/bind_declare.h
@@ -28,6 +28,7 @@ void tagmon(const Arg *arg);
 void spawn(const Arg *arg);
 void spawn_shell(const Arg *arg);
 void spawn_on_empty(const Arg *arg);
+void spawn_on_tag(const Arg *arg);
 void setkeymode(const Arg *arg);
 void switch_keyboard_layout(const Arg *arg);
 void setlayout(const Arg *arg);

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1074,14 +1074,15 @@ void centerwin(const Arg *arg) {
 	return;
 }
 
-void spawn_shell(const Arg *arg) {
+static pid_t spawn_shell_pid(const Arg *arg) {
 	if (!arg->v)
-		return;
+		return -1;
 
 	// hand the child an activation token so it can request activation
 	const char *activation_token = xdg_activation_v1_export_token();
+	pid_t pid = fork();
 
-	if (fork() == 0) {
+	if (pid == 0) {
 		signal(SIGSEGV, SIG_DFL);
 		signal(SIGABRT, SIG_DFL);
 		signal(SIGILL, SIG_DFL);
@@ -1106,8 +1107,10 @@ void spawn_shell(const Arg *arg) {
 					(char *)arg->v, strerror(errno));
 		_exit(EXIT_FAILURE);
 	}
-	return;
+	return pid;
 }
+
+void spawn_shell(const Arg *arg) { spawn_shell_pid(arg); }
 
 void spawn(const Arg *arg) {
 	if (!arg->v)
@@ -1170,6 +1173,19 @@ void spawn_on_empty(const Arg *arg) {
 		spawn_shell(arg);
 	}
 	return;
+}
+
+void spawn_on_tag(const Arg *arg) {
+	pid_t pid;
+
+	if (!arg->v || !arg->v[0] || !(arg->ui & TAGMASK))
+		return;
+
+	pid = spawn_shell_pid(arg);
+	if (pid < 0)
+		return;
+
+	spawn_on_tag_add(pid, arg->ui & TAGMASK);
 }
 
 void switch_keyboard_layout(const Arg *arg) {

--- a/src/mango.c
+++ b/src/mango.c
@@ -697,6 +697,9 @@ static void applybounds(
 	Client *c,
 	struct wlr_box *bbox); // 设置边界规则,能让一些窗口拥有比较适合的大小
 static void applyrules(Client *c); // 窗口规则应用,应用config.h中定义的窗口规则
+static void spawn_on_tag_add(pid_t pid, uint32_t tags);
+static bool spawn_on_tag_take(pid_t pid, uint32_t *tags);
+static void spawn_on_tag_cleanup(void);
 static void arrange(Monitor *m, bool want_animation,
 					bool from_view); // 布局函数,让窗口俺平铺规则移动和重置大小
 static void arrangelayer(Monitor *m, struct wl_list *list,
@@ -1007,6 +1010,15 @@ static const char *xdg_activation_v1_export_token(void);
 /* variables */
 static const char broken[] = "broken";
 static pid_t child_pid = -1;
+
+struct spawn_on_tag_record {
+	struct wl_list link;
+	pid_t pid;
+	uint32_t tags;
+	uint32_t created;
+};
+
+static struct wl_list spawn_on_tag_records;
 static int32_t locked;
 static uint32_t locked_mods = 0;
 static void *exclusive_focus;
@@ -1750,6 +1762,56 @@ void check_match_tag_floating_rule(Client *c, Monitor *mon) {
 	}
 }
 
+static void spawn_on_tag_prune(void) {
+	struct spawn_on_tag_record *record, *tmp;
+	uint32_t now = get_now_in_ms();
+
+	wl_list_for_each_safe(record, tmp, &spawn_on_tag_records, link) {
+		if (now - record->created > 60 * 1000) {
+			wl_list_remove(&record->link);
+			free(record);
+		}
+	}
+}
+
+static void spawn_on_tag_add(pid_t pid, uint32_t tags) {
+	struct spawn_on_tag_record *record;
+
+	spawn_on_tag_prune();
+	record = ecalloc(1, sizeof(*record));
+	record->pid = pid;
+	record->tags = tags;
+	record->created = get_now_in_ms();
+	wl_list_append(&spawn_on_tag_records, &record->link);
+}
+
+static bool spawn_on_tag_take(pid_t pid, uint32_t *tags) {
+	struct spawn_on_tag_record *record;
+
+	if (!pid)
+		return false;
+
+	spawn_on_tag_prune();
+	wl_list_for_each(record, &spawn_on_tag_records, link) {
+		if (isdescprocess(record->pid, pid)) {
+			*tags = record->tags;
+			wl_list_remove(&record->link);
+			free(record);
+			return true;
+		}
+	}
+	return false;
+}
+
+static void spawn_on_tag_cleanup(void) {
+	struct spawn_on_tag_record *record, *tmp;
+
+	wl_list_for_each_safe(record, tmp, &spawn_on_tag_records, link) {
+		wl_list_remove(&record->link);
+		free(record);
+	}
+}
+
 void applyrules(Client *c) {
 	/* rule matching */
 	const char *appid, *title;
@@ -1875,6 +1937,8 @@ void applyrules(Client *c) {
 
 	// apply swallow rule
 	c->pid = client_get_pid(c);
+	uint32_t spawn_tags = 0;
+	bool spawned_on_tag = spawn_on_tag_take(c->pid, &spawn_tags);
 	if (!c->noswallow && !c->isfloating && !client_is_float_type(c) &&
 		!c->surface.xdg->initial_commit) {
 		Client *p = termforwin(c);
@@ -1887,6 +1951,11 @@ void applyrules(Client *c) {
 			mon = p->mon;
 			newtags = p->tags;
 		}
+	}
+	if (spawned_on_tag) {
+		newtags = spawn_tags;
+		c->isopensilent = 1;
+		c->istagsilent = 1;
 	}
 
 	int32_t fullscreen_state_backup =
@@ -2755,6 +2824,7 @@ void cleanup(void) {
 	allow_frame_scheduling = false;
 
 	ipc_cleanup();
+	spawn_on_tag_cleanup();
 	cleanuplisteners();
 #ifdef XWAYLAND
 	wlr_xwayland_destroy(xwayland);
@@ -6646,6 +6716,7 @@ void setup(void) {
 	 */
 	wl_list_init(&clients);
 	wl_list_init(&fstack);
+	wl_list_init(&spawn_on_tag_records);
 	wl_list_init(&fadeout_clients);
 	wl_list_init(&fadeout_layers);
 


### PR DESCRIPTION
Adds `spawn_on_tag`, inspired by ability to spawn on a specific workspace in Hyprland.

Changed `spawn_shell` into `spawn_shell_pid` so each launch can be associated with its child process while preserving existing behavior.

Pending launches are tracked until the first mapped descendant appears, then placed silently on the requested tag mask without switching the current view. Unmatched launches expire after 60 seconds and are cleaned up on shutdown.

I am not sure the implementation is fully idiomatic, so feedback is welcome. Thanks!

https://github.com/user-attachments/assets/39b57ac9-355a-49ae-a8e4-c4873b6f06a2

