### PR TITLE
docs: fix moonlight link

### DIFF
--- a/docs/configuration/monitors.md
+++ b/docs/configuration/monitors.md
@@ -296,4 +296,4 @@ wlr-randr
 wlr-randr --output HEADLESS-1 --pos 1921,0 --scale 1 --custom-mode 1920x1080@60Hz
 ```
 
-Virtual monitors can be used for screen sharing with tools like [Sunshine](https://github.com/LizardByte/Sunshine) and [Moonlight](https://github.com/moonlight-stream/moonlight-android), allowing other devices to act as extended monitors.
+Virtual monitors can be used for screen sharing with tools like [Sunshine](https://github.com/LizardByte/Sunshine) and [Moonlight](https://github.com/moonlight-stream/moonlight-qt), allowing other devices to act as extended monitors.


### PR DESCRIPTION
The docs redirected to the moonlight-android repository link. This commit redirects to PC version.