### PR TITLE
feat: ignore switch_proportion_preset for floating windows

### DIFF
--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -816,8 +816,12 @@ void switch_proportion_preset(const Arg *arg) {
 		return;
 
 	Client *tc = arg->tc ? arg->tc : selmon->sel;
+
 	if (!tc)
 		return;
+
+	if (tc->isfloating)
+		return; // Do not switch scroller proportions for floating windows
 
 	tc = scroll_get_stack_head_client(tc);
 	if (!tc)


### PR DESCRIPTION
switch_proportion_preset is applied for floating windows, but should it? Floating windows are not scrolling, so proportion should not apply.

## Use case:

For example, as a user I would love to do this:

```conf
bindc = SUPER,         w, centerwin
bindc = SUPER,         w, switch_proportion_preset, next
```

With proportions not applying to floating windows, this would mean: *"center window if it is floating, if scrolling, set next proportion preset"*