### PR TITLE
feat: thumbnail switcher across all tags and monitors

### DIFF
--- a/docs/bindings/keys.md
+++ b/docs/bindings/keys.md
@@ -118,6 +118,7 @@ bindr=Super,Super_L,spawn,rofi -show run
 | `focus_window_or_workspace` | `left/right/up/down` | Focus window in direction; otherwise jump to the nearest adjacent tag that has clients, falling back to the next/previous tag if none. |
 | `focusstack` | `next/prev` | Cycle focus within the stack. |
 | `focuslast` | - | Focus the previously active window. |
+| `switcher` | `next/prev` | Open or cycle the all-tag, all-monitor thumbnail switcher. Releasing any modifier key selects. |
 | `exchange_client` | `left/right/up/down` | Swap window with neighbor in direction. |
 | `exchange_stack_client` | `next/prev` | Exchange window position in stack. |
 | `zoom` | - | Swap focused window with Master. |

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -702,6 +702,7 @@ static void set_binding_keymode(Config *config, char mode[28],
 
 int32_t parse_circle_direction(const char *str) {
 	// 将输入字符串转换为小写
+
 	char lowerStr[10];
 	int32_t i = 0;
 	while (str[i] && i < 9) {
@@ -1298,6 +1299,9 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 		func = centerwin;
 	} else if (strcmp(func_name, "focuslast") == 0) {
 		func = focuslast;
+	} else if (strcmp(func_name, "switcher") == 0) {
+		func = switcher;
+		(*arg).i = parse_circle_direction(arg_value);
 	} else if (strcmp(func_name, "toggle_trackpad_enable") == 0) {
 		func = toggle_trackpad_enable;
 	} else if (strcmp(func_name, "setoption") == 0) {

--- a/src/dispatch/bind_declare.h
+++ b/src/dispatch/bind_declare.h
@@ -6,6 +6,7 @@ void focus_window_or_workspace(const Arg *arg);
 void groupjoin(const Arg *arg);
 void groupleave(const Arg *arg);
 void toggleoverview(const Arg *arg);
+void switcher(const Arg *arg);
 void togglehdr(const Arg *arg);
 void togglejump(const Arg *arg);
 void set_proportion(const Arg *arg);

--- a/src/input/keyboard.h
+++ b/src/input/keyboard.h
@@ -508,6 +508,18 @@ void keypress(struct wl_listener *listener, void *data) {
 		toggleoverview(&(Arg){.i = 1});
 	}
 
+	if (switcher_is_active()) {
+		if (locked) {
+			switcher_close();
+		} else if (!group->virtual_keyboard &&
+				   event->state == WL_KEYBOARD_KEY_STATE_RELEASED &&
+				   ISMODEKEYCODE(keycode)) {
+			switcher_commit();
+			group->nsyms = 0;
+			wl_event_source_timer_update(group->key_repeat_source, 0);
+		}
+	}
+
 	if (config.cursor_hide_on_keypress && !cursor_hidden &&
 		event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 		hidecursor(NULL);

--- a/src/input/pointer.h
+++ b/src/input/pointer.h
@@ -441,6 +441,19 @@ bool handle_buttonpress(struct wlr_pointer_button_event *event) {
 		if (locked)
 			break;
 
+		if (switcher_is_active() &&
+			(event->button == BTN_LEFT || event->button == BTN_RIGHT)) {
+			Client *switcher_c = switcher_client_at(cursor->x, cursor->y);
+			if (!switcher_c)
+				switcher_close();
+			else if (event->button == BTN_LEFT)
+				switcher_commit_client(switcher_c);
+			else
+				pending_kill_client(switcher_c);
+			wlr_seat_pointer_notify_clear_focus(seat);
+			return true;
+		}
+
 		xytonode(cursor->x, cursor->y, &surface, NULL, NULL, &gb, NULL, NULL);
 		if (toplevel_from_wlr_surface(surface, &c, &l) >= 0) {
 			if (c && c->scene && c->scene->node.enabled &&

--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -2027,6 +2027,7 @@ void unmapnotify(struct wl_listener *listener, void *data) {
 	Monitor *m = NULL;
 	Client *nextfocus = NULL;
 	c->iskilling = 1;
+	switcher_close();
 	struct ScrollerStackNode *target_node =
 		c->mon ? find_scroller_node(
 					 c->mon->pertag->scroller_state[c->mon->pertag->curtag], c)

--- a/src/mango.c
+++ b/src/mango.c
@@ -1332,6 +1332,7 @@ static void ipc_notify_device_event(struct wlr_input_device *device);
 #include "layout/scroll.h"
 #include "layout/vertical.h"
 #include "overview/overview.h"
+#include "switcher/switcher.h"
 
 #include "manage/client.h"
 #include "input/keyboard.h"

--- a/src/switcher/switcher.h
+++ b/src/switcher/switcher.h
@@ -1,0 +1,450 @@
+#define SW_PAD 6
+#define SW_GAP 14
+#define SW_MARGIN 28
+#define SW_PANEL_FRAC 0.8f
+#define SW_TILE_FRAC 0.25f
+#define SW_ASPECT_MIN (9.0f / 16.0f)
+#define SW_ASPECT_MAX (12.0f / 5.0f)
+
+static const float switcher_panel_color[4] = {0.09f, 0.09f, 0.11f, 0.92f};
+
+struct switcher_tile {
+	Client *c;
+	struct wlr_scene_tree *tree;
+	struct wlr_scene_rect *frame;
+	struct wlr_scene_tree *content;
+	struct wl_list surfaces; /* switcher_surface.link */
+	int cw;
+	int row;
+};
+
+struct switcher_surface {
+	struct switcher_tile *tile;
+	struct wlr_surface *surface;
+	struct wlr_scene_buffer *buffer;
+	int sx, sy;
+	bool is_root;
+	struct wl_listener commit;
+	struct wl_listener destroy;
+	struct wl_listener output_sample;
+	struct wl_listener frame_done;
+	struct wl_list link;
+};
+
+static struct {
+	Monitor *mon;
+	struct wlr_scene_tree *tree;
+	struct wlr_scene_rect *bg;
+	struct switcher_tile *tiles;
+	int count;
+	int index;
+	int tile_h;
+} sw;
+
+static bool switcher_is_active(void) { return sw.tree != NULL; }
+
+static bool switcher_candidate(Client *c) {
+	if (!c->mon || c->iskilling || c->isminimized || c->isunglobal ||
+		c->is_logic_hide || !client_surface(c) || !client_surface(c)->mapped ||
+		client_is_unmanaged(c) || client_is_x11_popup(c))
+		return false;
+	return (int32_t)c->tags > 0;
+}
+
+static void switcher_content_size(Client *c, float *w, float *h) {
+#ifdef XWAYLAND
+	if (client_is_x11(c)) {
+		struct wlr_surface *s = client_surface(c);
+		*w = s->current.width;
+		*h = s->current.height;
+		return;
+	}
+#endif
+	*w = c->surface.xdg->geometry.width;
+	*h = c->surface.xdg->geometry.height;
+}
+
+// map the surface tree into the fixed tile box, re-run after each commit
+// because the content size or clip may change
+static void switcher_tile_layout(struct switcher_tile *tile) {
+	struct wlr_box clip;
+	float src_w, src_h;
+	client_get_clip(tile->c, &clip);
+	switcher_content_size(tile->c, &src_w, &src_h);
+	if (src_w <= 0 || src_h <= 0)
+		return;
+
+	float scale_x = (float)tile->cw / src_w;
+	float scale_y = (float)sw.tile_h / src_h;
+	struct switcher_surface *entry;
+	wl_list_for_each(entry, &tile->surfaces, link) {
+		struct wlr_surface *s = entry->surface;
+		if (entry->is_root) {
+			float ratio_x =
+				s->current.width > 0
+					? (float)s->current.buffer_width / s->current.width
+					: 1.0f;
+			float ratio_y =
+				s->current.height > 0
+					? (float)s->current.buffer_height / s->current.height
+					: 1.0f;
+			struct wlr_fbox src = {
+				.x = clip.x * ratio_x,
+				.y = clip.y * ratio_y,
+				.width = src_w * ratio_x,
+				.height = src_h * ratio_y,
+			};
+			wlr_scene_buffer_set_source_box(entry->buffer, &src);
+			wlr_scene_node_set_position(&entry->buffer->node, 0, 0);
+			wlr_scene_buffer_set_dest_size(entry->buffer, tile->cw, sw.tile_h);
+		} else {
+			wlr_scene_node_set_position(&entry->buffer->node,
+										(int)((entry->sx - clip.x) * scale_x),
+										(int)((entry->sy - clip.y) * scale_y));
+			wlr_scene_buffer_set_dest_size(entry->buffer,
+										   (int)(s->current.width * scale_x),
+										   (int)(s->current.height * scale_y));
+		}
+	}
+}
+
+static void switcher_surface_finish(struct switcher_surface *entry) {
+	wl_list_remove(&entry->commit.link);
+	wl_list_remove(&entry->destroy.link);
+	wl_list_remove(&entry->output_sample.link);
+	wl_list_remove(&entry->frame_done.link);
+	wl_list_remove(&entry->link);
+	free(entry);
+}
+
+static void switcher_surface_update_buffer(struct switcher_surface *entry) {
+	struct wlr_surface *surface = entry->surface;
+	struct wlr_scene_buffer *buffer = entry->buffer;
+
+	struct wlr_fbox source;
+	wlr_surface_get_buffer_source_box(surface, &source);
+	wlr_scene_buffer_set_source_box(buffer, &source);
+	wlr_scene_buffer_set_transform(buffer, surface->current.transform);
+
+	const struct wlr_alpha_modifier_surface_v1_state *alpha =
+		wlr_alpha_modifier_v1_get_surface_state(surface);
+	wlr_scene_buffer_set_opacity(buffer,
+								 alpha ? (float)alpha->multiplier : 1.0f);
+
+	enum wlr_color_transfer_function transfer_function =
+		WLR_COLOR_TRANSFER_FUNCTION_GAMMA22;
+	enum wlr_color_named_primaries primaries = WLR_COLOR_NAMED_PRIMARIES_SRGB;
+	const struct wlr_image_description_v1_data *image =
+		wlr_surface_get_image_description_v1_data(surface);
+	if (image) {
+		transfer_function =
+			wlr_color_manager_v1_transfer_function_to_wlr(image->tf_named);
+		primaries =
+			wlr_color_manager_v1_primaries_to_wlr(image->primaries_named);
+	}
+	wlr_scene_buffer_set_transfer_function(buffer, transfer_function);
+	wlr_scene_buffer_set_primaries(buffer, primaries);
+
+	enum wlr_color_encoding encoding = WLR_COLOR_ENCODING_NONE;
+	enum wlr_color_range range = WLR_COLOR_RANGE_NONE;
+	const struct wlr_color_representation_v1_surface_state *representation =
+		wlr_color_representation_v1_get_surface_state(surface);
+	if (representation) {
+		if (representation->coefficients)
+			encoding = wlr_color_representation_v1_color_encoding_to_wlr(
+				representation->coefficients);
+		if (representation->range)
+			range = wlr_color_representation_v1_color_range_to_wlr(
+				representation->range);
+	}
+	wlr_scene_buffer_set_color_encoding(buffer, encoding);
+	wlr_scene_buffer_set_color_range(buffer, range);
+
+	if (!surface->buffer || surface->current.width <= 0 ||
+		surface->current.height <= 0) {
+		wlr_scene_buffer_set_buffer(buffer, NULL);
+		return;
+	}
+
+	struct wlr_scene_buffer_set_buffer_options options = {
+		.damage = &surface->buffer_damage,
+	};
+	struct wlr_linux_drm_syncobj_surface_v1_state *syncobj =
+		wlr_linux_drm_syncobj_v1_get_surface_state(surface);
+	if (syncobj) {
+		options.wait_timeline = syncobj->acquire_timeline;
+		options.wait_point = syncobj->acquire_point;
+	}
+	wlr_scene_buffer_set_buffer_with_options(buffer, &surface->buffer->base,
+											 &options);
+}
+
+static void switcher_surface_commit(struct wl_listener *listener, void *data) {
+	struct switcher_surface *entry = wl_container_of(listener, entry, commit);
+	switcher_surface_update_buffer(entry);
+	switcher_tile_layout(entry->tile);
+}
+
+static void switcher_surface_destroy(struct wl_listener *listener, void *data) {
+	struct switcher_surface *entry = wl_container_of(listener, entry, destroy);
+	struct wlr_scene_buffer *buffer = entry->buffer;
+	switcher_surface_finish(entry);
+	wlr_scene_node_destroy(&buffer->node);
+}
+
+static void switcher_surface_output_sample(struct wl_listener *listener,
+										   void *data) {
+	struct switcher_surface *entry =
+		wl_container_of(listener, entry, output_sample);
+	const struct wlr_scene_output_sample_event *event = data;
+	if (entry->buffer->primary_output != event->output)
+		return;
+
+	struct wlr_output *output = event->output->output;
+	if (event->direct_scanout)
+		wlr_presentation_surface_scanned_out_on_output(entry->surface, output);
+	else
+		wlr_presentation_surface_textured_on_output(entry->surface, output);
+
+	struct wlr_linux_drm_syncobj_surface_v1_state *syncobj =
+		wlr_linux_drm_syncobj_v1_get_surface_state(entry->surface);
+	if (syncobj && event->release_timeline)
+		wlr_linux_drm_syncobj_v1_state_add_release_point(
+			syncobj, event->release_timeline, event->release_point,
+			output->event_loop);
+}
+
+// hidden clients are paced by the preview buffer
+static void switcher_surface_frame_done(struct wl_listener *listener,
+										void *data) {
+	struct switcher_surface *entry =
+		wl_container_of(listener, entry, frame_done);
+	struct wlr_scene_frame_done_event *event = data;
+	if (entry->buffer->primary_output == event->output)
+		wlr_surface_send_frame_done(entry->surface, &event->when);
+}
+
+static void switcher_tile_add_surface(struct wlr_surface *surface, int sx,
+									  int sy, void *data) {
+	struct switcher_tile *tile = data;
+
+	// only the real scene surface may update wl_surface output membership
+	struct wlr_scene_buffer *buffer =
+		wlr_scene_buffer_create(tile->content, NULL);
+	if (!buffer)
+		return;
+
+	struct switcher_surface *entry = ecalloc(1, sizeof(*entry));
+	entry->tile = tile;
+	entry->surface = surface;
+	entry->buffer = buffer;
+	entry->sx = sx;
+	entry->sy = sy;
+	entry->is_root = surface == client_surface(tile->c);
+	wlr_scene_buffer_set_filter_mode(entry->buffer, WLR_SCALE_FILTER_BILINEAR);
+	switcher_surface_update_buffer(entry);
+
+	LISTEN(&surface->events.commit, &entry->commit, switcher_surface_commit);
+	LISTEN(&surface->events.destroy, &entry->destroy, switcher_surface_destroy);
+	LISTEN(&buffer->events.output_sample, &entry->output_sample,
+		   switcher_surface_output_sample);
+	LISTEN(&buffer->events.frame_done, &entry->frame_done,
+		   switcher_surface_frame_done);
+	wl_list_insert(&tile->surfaces, &entry->link);
+}
+
+static void switcher_tile_create(struct switcher_tile *tile, Client *c) {
+	tile->c = c;
+	wl_list_init(&tile->surfaces);
+	float src_w, src_h;
+	switcher_content_size(c, &src_w, &src_h);
+	float aspect = src_w > 0 && src_h > 0 ? src_w / src_h : 1.0f;
+	aspect = MANGO_MAX(SW_ASPECT_MIN, MANGO_MIN(aspect, SW_ASPECT_MAX));
+	tile->cw = MANGO_MAX(1, (int)(sw.tile_h * aspect));
+
+	tile->tree = wlr_scene_tree_create(sw.tree);
+	tile->frame = wlr_scene_rect_create(tile->tree, 1, 1, config.bordercolor);
+	tile->content = wlr_scene_tree_create(tile->tree);
+	wlr_scene_node_set_position(&tile->content->node, SW_PAD, SW_PAD);
+	wlr_surface_for_each_surface(client_surface(c), switcher_tile_add_surface,
+								 tile);
+	switcher_tile_layout(tile);
+}
+
+static void switcher_layout(void) {
+	int frame_h = sw.tile_h + 2 * SW_PAD;
+	int maxrow_w =
+		MANGO_MAX(1, (int)(sw.mon->m.width * SW_PANEL_FRAC) - 2 * SW_MARGIN);
+
+	int nrows = 1;
+	int row_w = 0;
+	int content_w = 0;
+	for (int i = 0; i < sw.count; i++) {
+		struct switcher_tile *tile = &sw.tiles[i];
+		int fw = tile->cw + 2 * SW_PAD;
+		if (row_w > 0 && row_w + SW_GAP + fw > maxrow_w) {
+			nrows++;
+			row_w = fw;
+		} else {
+			row_w = row_w == 0 ? fw : row_w + SW_GAP + fw;
+		}
+		tile->row = nrows - 1;
+		content_w = MANGO_MAX(content_w, row_w);
+	}
+
+	int *rowsw = ecalloc(nrows, sizeof(*rowsw));
+	for (int i = 0; i < sw.count; i++) {
+		struct switcher_tile *tile = &sw.tiles[i];
+		int fw = tile->cw + 2 * SW_PAD;
+		rowsw[tile->row] += rowsw[tile->row] == 0 ? fw : SW_GAP + fw;
+	}
+
+	int panel_w = content_w + 2 * SW_MARGIN;
+	int panel_h = 2 * SW_MARGIN + nrows * frame_h + (nrows - 1) * SW_GAP;
+	wlr_scene_node_set_position(&sw.tree->node,
+								sw.mon->m.x + (sw.mon->m.width - panel_w) / 2,
+								sw.mon->m.y + (sw.mon->m.height - panel_h) / 2);
+	wlr_scene_rect_set_size(sw.bg, panel_w, panel_h);
+
+	int row = -1;
+	int x = 0;
+	for (int i = 0; i < sw.count; i++) {
+		struct switcher_tile *tile = &sw.tiles[i];
+		if (tile->row != row) {
+			row = tile->row;
+			x = SW_MARGIN + (content_w - rowsw[row]) / 2;
+		}
+		wlr_scene_node_set_position(&tile->tree->node, x,
+									SW_MARGIN + row * (frame_h + SW_GAP));
+		wlr_scene_rect_set_size(tile->frame, tile->cw + 2 * SW_PAD, frame_h);
+		x += tile->cw + 2 * SW_PAD + SW_GAP;
+	}
+	free(rowsw);
+}
+
+static void switcher_apply_highlight(void) {
+	for (int i = 0; i < sw.count; i++)
+		wlr_scene_rect_set_color(sw.tiles[i].frame, i == sw.index
+														? config.focuscolor
+														: config.bordercolor);
+}
+
+static void switcher_close(void) {
+	if (!switcher_is_active())
+		return;
+	for (int i = 0; i < sw.count; i++) {
+		struct switcher_surface *entry, *tmp;
+		wl_list_for_each_safe(entry, tmp, &sw.tiles[i].surfaces, link) {
+			switcher_surface_finish(entry);
+		}
+	}
+	wlr_scene_node_destroy(&sw.tree->node);
+	free(sw.tiles);
+	memset(&sw, 0, sizeof(sw));
+}
+
+static void switcher_commit_client(Client *tc) {
+	switcher_close();
+	if (!switcher_candidate(tc))
+		return;
+	if (!VISIBLEON(tc, tc->mon))
+		view_in_mon(&(Arg){.ui = get_tags_first_tag(tc->tags)}, true, tc->mon,
+					true);
+	focusclient(tc, 1);
+}
+
+static void switcher_commit(void) {
+	if (!switcher_is_active())
+		return;
+	switcher_commit_client(sw.tiles[sw.index].c);
+}
+
+static Client *switcher_client_at(double lx, double ly) {
+	if (!switcher_is_active())
+		return NULL;
+	for (int i = 0; i < sw.count; i++) {
+		struct switcher_tile *tile = &sw.tiles[i];
+		struct wlr_box box = {
+			.width = tile->cw + 2 * SW_PAD,
+			.height = sw.tile_h + 2 * SW_PAD,
+		};
+		if (!wlr_scene_node_coords(&tile->tree->node, &box.x, &box.y) ||
+			!wlr_box_contains_point(&box, lx, ly))
+			continue;
+		return tile->c;
+	}
+	return NULL;
+}
+
+static void switcher_open(int dir) {
+	Client *c;
+	Monitor *m;
+	int n = 0;
+
+	wl_list_for_each(m, &mons, link) {
+		if (m->isoverview)
+			return;
+	}
+	wl_list_for_each(c, &fstack, flink) {
+		if (switcher_candidate(c))
+			n++;
+	}
+	if (n == 0)
+		return;
+
+	sw.mon = selmon;
+	int max_row_w = (int)(sw.mon->m.width * SW_PANEL_FRAC) - 2 * SW_MARGIN;
+	int max_panel_h = (int)(sw.mon->m.height * SW_PANEL_FRAC);
+	// size against the widest allowed tile so the panel always fits
+	sw.tile_h = 1;
+	for (int cols = 1; cols <= n; cols++) {
+		int rows = (n + cols - 1) / cols;
+		int h_by_w =
+			(int)((max_row_w - (cols - 1) * SW_GAP - 2 * cols * SW_PAD) /
+				  (cols * SW_ASPECT_MAX));
+		int h_by_h =
+			(max_panel_h - 2 * SW_MARGIN - (rows - 1) * SW_GAP) / rows -
+			2 * SW_PAD;
+		int h = MANGO_MIN((int)(sw.mon->m.height * SW_TILE_FRAC),
+						  MANGO_MIN(h_by_w, h_by_h));
+		sw.tile_h = MANGO_MAX(sw.tile_h, h);
+	}
+
+	sw.tree = wlr_scene_tree_create(layers[LyrOverlay]);
+	sw.bg = wlr_scene_rect_create(sw.tree, 1, 1, switcher_panel_color);
+	sw.tiles = ecalloc(n, sizeof(*sw.tiles));
+	int current_index = -1;
+	wl_list_for_each(c, &fstack, flink) {
+		if (!switcher_candidate(c))
+			continue;
+		if (c == selmon->sel)
+			current_index = sw.count;
+		switcher_tile_create(&sw.tiles[sw.count++], c);
+	}
+	sw.index = current_index >= 0 ? (current_index + dir + sw.count) % sw.count
+								  : (dir > 0 ? 0 : sw.count - 1);
+	switcher_layout();
+	switcher_apply_highlight();
+
+	// restart render loops of clients idling without frame callbacks so
+	// tiles of hidden windows stay live, like overview cards
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	for (int i = 0; i < sw.count; i++)
+		client_send_frame_done(sw.tiles[i].c, &now);
+}
+
+static void switcher_cycle(int dir) {
+	sw.index = (sw.index + dir + sw.count) % sw.count;
+	switcher_apply_highlight();
+}
+
+void switcher(const Arg *arg) {
+	int dir = arg && arg->i == PREV ? -1 : 1;
+	if (locked || !selmon || selmon->is_jump_mode)
+		return;
+	if (switcher_is_active())
+		switcher_cycle(dir);
+	else
+		switcher_open(dir);
+}


### PR DESCRIPTION
switcher will show live preview for all windows across all workspace tags and monitors

<img width="3435" height="1430" alt="Screenshot from 2026-08-21 14-13-00" src="https://github.com/user-attachments/assets/d8b874d5-682a-4722-8b58-bfd4cf3ac8db" />
