### PR TITLE
ipc: fix focusid not working, add new dispatchers

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -719,8 +719,12 @@ int32_t parse_direction(const char *str) {
 
 int32_t parse_force(const char *str) {
 	// 将输入字符串转换为小写
+	if (!str)
+		return UNFORCE;
+	
 	char lowerStr[10];
 	int32_t i = 0;
+	
 	while (str[i] && i < 9) {
 		lowerStr[i] = tolower(str[i]);
 		i++;
@@ -1206,6 +1210,7 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 		func = groupleave;
 	} else if (strcmp(func_name, "focusid") == 0) {
 		func = focusid;
+		(*arg).ui = atoi(arg_value);
 	} else if (strcmp(func_name, "incnmaster") == 0) {
 		func = incnmaster;
 		(*arg).i = atoi(arg_value);
@@ -1269,6 +1274,10 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 	} else if (strcmp(func_name, "killclient") == 0) {
 		func = killclient;
 		(*arg).i = parse_force(arg_value);
+	} else if (strcmp(func_name, "killid") == 0) {
+		func = killid;
+		(*arg).ui = atoi(arg_value);
+		(*arg).i = parse_force(arg_value2);
 	} else if (strcmp(func_name, "centerwin") == 0) {
 		func = centerwin;
 	} else if (strcmp(func_name, "focuslast") == 0) {
@@ -1332,8 +1341,14 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 		func = switch_layout;
 	} else if (strcmp(func_name, "togglefloating") == 0) {
 		func = togglefloating;
+	} else if (strcmp(func_name, "togglefloatingid") == 0) {
+		func = togglefloatingid;
+		(*arg).ui = atoi(arg_value);
 	} else if (strcmp(func_name, "togglefullscreen") == 0) {
 		func = togglefullscreen;
+	} else if (strcmp(func_name, "togglefullscreenid") == 0) {
+		func = togglefullscreenid;
+		(*arg).ui = atoi(arg_value);
 	} else if (strcmp(func_name, "togglefakefullscreen") == 0) {
 		func = togglefakefullscreen;
 	} else if (strcmp(func_name, "toggleoverlay") == 0) {
@@ -1408,6 +1423,11 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 		func = tag;
 		(*arg).ui = parse_tag_mask(arg_value);
 		(*arg).i = atoi(arg_value2);
+	} else if (strcmp(func_name, "tagid") == 0) {
+		func = tagid;
+		(*arg).ui2 = atoi(arg_value);  // id
+		(*arg).ui = parse_tag_mask(arg_value2); // tag
+		(*arg).i = atoi(arg_value3);  // synctag
 	} else if (strcmp(func_name, "view") == 0) {
 		func = bind_to_view;
 		(*arg).ui = parse_tag_mask(arg_value);

--- a/src/dispatch/bind_declare.h
+++ b/src/dispatch/bind_declare.h
@@ -87,3 +87,7 @@ void dwindle_split_horizontal(const Arg *arg);
 void dwindle_split_vertical(const Arg *arg);
 void dwindle_toggle_current_split(const Arg *arg);
 void focusid(const Arg *arg);
+void killid(const Arg *arg);
+void tagid(const Arg *arg);
+void togglefloatingid(const Arg *arg);
+void togglefullscreenid(const Arg *arg);

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -511,6 +511,20 @@ void killclient(const Arg *arg) {
 	return;
 }
 
+void killid(const Arg *arg) {
+	Client *c = get_client_by_id(arg->ui);
+
+	if (c) {
+		if (arg->i == FORCE) {
+			client_pending_force_kill(c);
+		} else {
+			pending_kill_client(c);
+		}
+	}
+
+	return;
+}
+
 void moveresize(const Arg *arg) {
 	const char *cursors[] = {"nw-resize", "ne-resize", "sw-resize",
 							 "se-resize"};
@@ -1293,9 +1307,18 @@ void switch_layout(const Arg *arg) {
 void tag(const Arg *arg) {
 	if (!selmon)
 		return;
+
 	Client *target_client = arg->tc ? arg->tc : selmon->sel;
 	tag_client(arg, target_client);
-	return;
+}
+
+void tagid(const Arg *arg) {
+	if (!selmon)
+		return;
+	
+	Client *c = get_client_by_id(arg->ui2);
+
+	tag_client(arg, c);
 }
 
 void tagmon(const Arg *arg) {
@@ -1501,7 +1524,6 @@ void togglefakefullscreen(const Arg *arg) {
 	Client *sel = arg->tc ? arg->tc : focustop(selmon);
 	if (sel)
 		setfakefullscreen(sel, !sel->isfakefullscreen);
-	return;
 }
 
 void togglefloating(const Arg *arg) {
@@ -1525,7 +1547,29 @@ void togglefloating(const Arg *arg) {
 	}
 
 	setfloating(sel, isfloating);
-	return;
+}
+
+void togglefloatingid(const Arg *arg) {
+	if (!selmon || grabc)
+		return;
+
+	if (selmon && selmon->isoverview)
+		return;
+
+	Client *c = get_client_by_id(arg->ui);
+
+	if (!c)
+		return;
+
+	bool isfloating = c->isfloating;
+
+	if ((c->isfullscreen || c->ismaximizescreen)) {
+		isfloating = 1;
+	} else {
+		isfloating = !c->isfloating;
+	}
+
+	setfloating(c, isfloating);
 }
 
 void togglefullscreen(const Arg *arg) {
@@ -1544,7 +1588,25 @@ void togglefullscreen(const Arg *arg) {
 		setfullscreen(sel, 0, true);
 	else
 		setfullscreen(sel, 1, true);
-	return;
+}
+
+void togglefullscreenid(const Arg *arg) {
+	if (!selmon)
+		return;
+
+	Client *c = get_client_by_id(arg->ui);
+
+	if (!c)
+		return;
+
+	c->is_scratchpad_show = 0;
+	c->is_in_scratchpad = 0;
+	c->isnamedscratchpad = 0;
+
+	if (c->isfullscreen)
+		setfullscreen(c, 0, true);
+	else
+		setfullscreen(c, 1, true);
 }
 
 void toggleglobal(const Arg *arg) {
@@ -2317,10 +2379,10 @@ void dwindle_toggle_current_split(const Arg *arg) {
 }
 
 void focusid(const Arg *arg) {
-	if (!selmon || !arg->tc)
+	if (!selmon)
 		return;
 
-	Client *c = arg->tc;
+	Client *c = get_client_by_id(arg->ui);
 
 	if (c->swallowdby)
 		return;

--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -3418,6 +3418,18 @@ void client_tile_resize(Client *c, struct wlr_box geo, int32_t interact) {
 
 uint32_t generate_client_id(void) { return ++next_client_id; }
 
+Client* get_client_by_id(uint32_t id) 
+{
+	Client *c = NULL;
+
+	wl_list_for_each(c, &clients, link) {
+		if (c->id == id)
+			break;
+	}
+
+	return c;
+}
+
 void client_pending_force_kill(Client *c) {
 	if (!c)
 		return;

--- a/src/mango.c
+++ b/src/mango.c
@@ -1079,6 +1079,7 @@ static void iter_xdg_scene_buffers(struct wlr_scene_buffer *buffer, int32_t sx,
 								   int32_t sy, void *user_data);
 static void unminimize(Client *c);
 Client *termforwin(Client *w);
+Client *get_client_by_id(uint32_t id);
 Client *get_client_by_id_or_title(const char *arg_id, const char *arg_title);
 Client *center_tiled_select(Monitor *m);
 Client *find_client_by_direction(Client *tc, const Arg *arg, bool findfloating);


### PR DESCRIPTION
Adds more dispatchers to interact with clients by ID

- [x] fix focusid
- [x] add killid
- [x] add togglefloatingid
- [x] add togglefullscreenid
- [x] add tagid

## Why?

I'm trying to port nwg-dock-hyprland to mango, it lacks these