### PR TITLE
fix: make floating windows appear behind layers

### DIFF
--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -3545,10 +3545,11 @@ void client_reparent_group(Client *c) {
 	if (!c || !c->mon)
 		return;
 
-	int32_t layer = c->isoverlay					   ? LyrOverlay
-					: c->isfloating || c->isfullscreen ? LyrTop
-					: c->ismaximizescreen			   ? LyrMaximize
-													   : LyrTile;
+	int32_t layer = c->isoverlay	      ? LyrOverlay
+					: c->isfloating       ? LyrFloating
+					: c->isfullscreen     ? LyrTop
+					: c->ismaximizescreen ? LyrMaximize
+										  : LyrTile;
 
 	Client *head = c;
 	while (head->group_prev)

--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -3545,10 +3545,11 @@ void client_reparent_group(Client *c) {
 	if (!c || !c->mon)
 		return;
 
-	int32_t layer = c->isoverlay					   ? LyrOverlay
-					: c->isfloating || c->isfullscreen ? LyrTop
-					: c->ismaximizescreen			   ? LyrMaximize
-													   : LyrTile;
+	int32_t layer = c->isoverlay	      ? LyrOverlay
+					: c->isfullscreen     ? LyrTop
+					: c->isfloating       ? LyrFloating
+					: c->ismaximizescreen ? LyrMaximize
+										  : LyrTile;
 
 	Client *head = c;
 	while (head->group_prev)

--- a/src/mango.c
+++ b/src/mango.c
@@ -201,6 +201,7 @@ enum {
 	LyrBottom,
 	LyrTile,
 	LyrMaximize,
+	LyrFloating,
 	LyrTop,
 	LyrFadeOut,
 	LyrOverlay,


### PR DESCRIPTION
This PR fixes floating windows conflicting with layer surfaces and full screened windows on the appearance layer. Forces floating windows to be behind full screened windows and layers 

