### PR TITLE
fix: layers handle slide geo correctly for negative margins

### DIFF
--- a/src/animation/layer.h
+++ b/src/animation/layer.h
@@ -131,23 +131,23 @@ void set_layer_dir_animaiton(LayerSurface *l, struct wlr_box *geo) {
 	switch (slide_direction) {
 	case UP:
 		geo->x = l->geom.x;
-		geo->y = usable_area.y - l->geom.height;
+		geo->y = l->geom.y - l->geom.height;
 		break;
 	case DOWN:
 		geo->x = l->geom.x;
-		geo->y = usable_area.y + usable_area.height;
+		geo->y = l->geom.y + l->geom.height;
 		break;
 	case LEFT:
-		geo->x = usable_area.x - l->geom.width;
+		geo->x = l->geom.x - l->geom.width;
 		geo->y = l->geom.y;
 		break;
 	case RIGHT:
-		geo->x = usable_area.x + usable_area.width;
+		geo->x = l->geom.x + l->geom.width;
 		geo->y = l->geom.y;
 		break;
 	default:
 		geo->x = l->geom.x;
-		geo->y = 0 - l->geom.height;
+		geo->y = l->geom.y - l->geom.height;
 	}
 }
 

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -2956,7 +2956,7 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 		ConfigEnv *env = calloc(1, sizeof(ConfigEnv));
 
 		const char *needle = "~/";
-		
+
 		if (strstr(env_value, needle)) {
 			const char *home = getenv("HOME");
 
@@ -2974,7 +2974,7 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 			size_t len = strlen(env_value) + 1;
 
 			for (char *p = strstr(env_value, needle); p;
-				p = strstr(p + rlen, needle))
+				 p = strstr(p + rlen, needle))
 				len += hlen - rlen;
 
 			env->value = malloc(len);


### PR DESCRIPTION
Some layers might have a negative margins, which is handled correctly in `get_layer_target_geometry` however, negative margins might go beyond `usable_area`. This will break the animation in such case. 