### PR TITLE
feat: Add smartkill

### DIFF
--- a/assets/config.conf
+++ b/assets/config.conf
@@ -88,6 +88,7 @@ overviewgappo=30
 no_border_when_single=0
 axis_bind_apply_timeout=100
 focus_on_activate=1
+smartkill=0
 idleinhibit_ignore_visible=0
 sloppyfocus=1
 warpcursor=1

--- a/docs/bindings/keys.md
+++ b/docs/bindings/keys.md
@@ -95,7 +95,7 @@ bindr=Super,Super_L,spawn,rofi -show run
 
 | Command | Param | Description |
 | :--- | :--- | :--- |
-| `killclient` | `force` | Close the focused window. If `force` is specified, sends `SIGKILL`. |
+| `killclient` | `force` | Close the focused window. If `force` is specified, sends `SIGKILL`. With `smartkill=1`, a window on multiple tags is first detached from all viewed tags and only closed if no other tags remain (`force` always kills). |
 | `togglefloating` | - | Toggle floating state. |
 | `toggle_all_floating` | - | Toggle all visible clients floating state. |
 | `togglefullscreen` | - | Toggle fullscreen. |

--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -49,6 +49,7 @@ description: Advanced settings for XWayland, focus behavior, and system integrat
 | `snap_distance` | `30` | Max distance (pixels) to trigger floating snap. |
 | `no_border_when_single` | `0` | Remove window borders when only one window is visible on the tag. |
 | `smartgaps` | `0` | Disable gaps when only one window is present. |
+| `smartkill` | `0` | When `1`, `killclient` first detaches the window from all currently viewed tags; the window is only closed if it has no other tags left. `force` kills always bypass this. |
 | `idleinhibit_ignore_visible` | `0` | Allow invisible clients (e.g., background audio players) to inhibit idle. |
 | `tag_carousel` | `0` | Enable tag carousel (cycling through tags). |
 | `drag_tile_refresh_interval` | `8.0` | Interval (1.0–16.0) to refresh tiled window resize during drag. Too small may cause application lag. |

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -361,6 +361,7 @@ typedef struct {
 
 	uint32_t axis_bind_apply_timeout;
 	uint32_t focus_on_activate;
+	int32_t smartkill;
 	int32_t idleinhibit_ignore_visible;
 	int32_t sloppyfocus;
 	int32_t warpcursor;
@@ -1971,6 +1972,8 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 		config->axis_bind_apply_timeout = atoi(value);
 	} else if (strcmp(key, "focus_on_activate") == 0) {
 		config->focus_on_activate = atoi(value);
+	} else if (strcmp(key, "smartkill") == 0) {
+		config->smartkill = atoi(value);
 	} else if (strcmp(key, "numlockon") == 0) {
 		config->numlockon = atoi(value);
 	} else if (strcmp(key, "idleinhibit_ignore_visible") == 0) {
@@ -2956,7 +2959,7 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 		ConfigEnv *env = calloc(1, sizeof(ConfigEnv));
 
 		const char *needle = "~/";
-		
+
 		if (strstr(env_value, needle)) {
 			const char *home = getenv("HOME");
 
@@ -2974,7 +2977,7 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 			size_t len = strlen(env_value) + 1;
 
 			for (char *p = strstr(env_value, needle); p;
-				p = strstr(p + rlen, needle))
+				 p = strstr(p + rlen, needle))
 				len += hlen - rlen;
 
 			env->value = malloc(len);
@@ -4278,6 +4281,7 @@ void override_config(void) {
 	config.axis_bind_apply_timeout =
 		CLAMP_INT(config.axis_bind_apply_timeout, 0, 1000);
 	config.focus_on_activate = CLAMP_INT(config.focus_on_activate, 0, 1);
+	config.smartkill = CLAMP_INT(config.smartkill, 0, 1);
 	config.idleinhibit_ignore_visible =
 		CLAMP_INT(config.idleinhibit_ignore_visible, 0, 1);
 	config.sloppyfocus = CLAMP_INT(config.sloppyfocus, 0, 1);
@@ -4430,6 +4434,7 @@ void set_value_default() {
 
 	config.axis_bind_apply_timeout = 100;
 	config.focus_on_activate = 1;
+	config.smartkill = 0;
 	config.new_is_master = 1;
 	config.default_mfact = 0.55f;
 	config.default_nmaster = 1;

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -505,6 +505,18 @@ void killclient(const Arg *arg) {
 		if (arg->i == FORCE) {
 			client_pending_force_kill(c);
 		} else {
+			if (config.smartkill && c->mon && !c->isglobal && !c->isunglobal &&
+				!c->is_in_scratchpad) {
+				uint32_t newtags =
+					c->tags & ~(c->mon->tagset[c->mon->seltags] & TAGMASK);
+				if (newtags && newtags != c->tags) {
+					c->tags = newtags;
+					focusclient(focustop(c->mon), 1);
+					arrange(c->mon, false, false);
+					printstatus(IPC_WATCH_ARRANGGE);
+					return;
+				}
+			}
 			pending_kill_client(c);
 		}
 	}


### PR DESCRIPTION
 `smartkill` | `0` | When `1`, `killclient` first detaches the window from all currently viewed tags; the window is only closed if it has no other tags left. `force` kills always bypass this. 

 This idea is greatly inspired by the great idea of https://github.com/mangowm/mango/pull/1001

More info on the feature on the [1001 PR](https://github.com/mangowm/mango/pull/1001)