### PR TITLE
fix(nix): replace deprecated `stdenv.isLinux`

### DIFF
--- a/nix/hm-modules.nix
+++ b/nix/hm-modules.nix
@@ -32,7 +32,7 @@ in
       systemd = {
         enable = mkOption {
           type = types.bool;
-          default = pkgs.stdenv.isLinux;
+          default = pkgs.stdenv.hostPlatform.isLinux;
           example = false;
           description = ''
             Whether to enable {file}`mango-session.target` on


### PR DESCRIPTION
`stdenv.isLinux` (along with a few other `stdenv.is*` attributes) were deprecated in https://github.com/NixOS/nixpkgs/commit/4bb4cff36852dda1e32fc2ee0d377b516ca02339. This stops builds from generating this deprecation warning:

> evaluation warning: stdenv.isLinux is deprecated, use stdenv.hostPlatform.isLinux instead