### PR TITLE
fix: no_border_when_single applying to single floating window

### DIFF
--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -688,7 +688,7 @@ bool check_hit_no_border(Client *c) {
 		hit_no_border = true;
 	}
 
-	if (config.no_border_when_single && c && c->mon &&
+	if (config.no_border_when_single && c && c->mon && !c->isfloating &&
 		((ISSCROLLTILED(c) && c->mon->visible_fake_tiling_clients == 1) ||
 		 c->mon->visible_clients == 1)) {
 		hit_no_border = true;


### PR DESCRIPTION
Fixes 'no_border_when_single=1' applying when the only window on the tag is floating