### PR TITLE
feat: add animations for minimizing, unminimizing and scratchpad

### DIFF
--- a/assets/config.conf
+++ b/assets/config.conf
@@ -79,7 +79,6 @@ dwindle_preserve_split=0
 # Overview Setting
 hotarea_size=10
 enable_hotarea=0
-ov_tab_mode=1
 overviewgappi=5
 overviewgappo=30
 

--- a/assets/config.conf
+++ b/assets/config.conf
@@ -80,7 +80,6 @@ dwindle_preserve_split=0
 hotarea_size=10
 enable_hotarea=0
 ov_tab_mode=1
-ov_tab_mode_launch_next=0
 overviewgappi=5
 overviewgappo=30
 

--- a/docs/bindings/keys.md
+++ b/docs/bindings/keys.md
@@ -117,9 +117,8 @@ bindr=Super,Super_L,spawn,rofi -show run
 | `focusdir` | `left/right/up/down` | Focus window in direction. |
 | `focus_window_or_workspace` | `left/right/up/down` | Focus window in direction; otherwise jump to the nearest adjacent tag that has clients, falling back to the next/previous tag if none. |
 | `focusstack` | `next/prev` | Cycle focus within the stack. |
-| `overcicle` | - | Open overview when closed; while it is open, each trigger cycles focus to the next window on the current monitor. |
 | `focuslast` | - | Focus the previously active window. |
-| `switcher` | `next/prev` | Open or cycle the all-tag, all-monitor thumbnail switcher. Releasing any modifier key selects. |
+| `switcher` | `next/prev`, `all_tag_next/all_tag_prev`, `all_next/all_prev` | Open or cycle the thumbnail switcher. `next`/`prev` list the current tag's windows, `all_tag_next`/`all_tag_prev` list all tags on the current monitor, `all_next`/`all_prev` list all monitors and tags. Releasing any modifier key selects. |
 | `exchange_client` | `left/right/up/down` | Swap window with neighbor in direction. |
 | `exchange_stack_client` | `next/prev` | Exchange window position in stack. |
 | `zoom` | - | Swap focused window with Master. |

--- a/docs/bindings/keys.md
+++ b/docs/bindings/keys.md
@@ -118,6 +118,7 @@ bindr=Super,Super_L,spawn,rofi -show run
 | `focus_window_or_workspace` | `left/right/up/down` | Focus window in direction; otherwise jump to the nearest adjacent tag that has clients, falling back to the next/previous tag if none. |
 | `focusstack` | `next/prev` | Cycle focus within the stack. |
 | `focuslast` | - | Focus the previously active window. |
+| `switcher` | `next/prev` | Open or cycle the all-tag, all-monitor thumbnail switcher. Releasing any modifier key selects. |
 | `exchange_client` | `left/right/up/down` | Swap window with neighbor in direction. |
 | `exchange_stack_client` | `next/prev` | Exchange window position in stack. |
 | `zoom` | - | Swap focused window with Master. |

--- a/docs/bindings/keys.md
+++ b/docs/bindings/keys.md
@@ -117,6 +117,7 @@ bindr=Super,Super_L,spawn,rofi -show run
 | `focusdir` | `left/right/up/down` | Focus window in direction. |
 | `focus_window_or_workspace` | `left/right/up/down` | Focus window in direction; otherwise jump to the nearest adjacent tag that has clients, falling back to the next/previous tag if none. |
 | `focusstack` | `next/prev` | Cycle focus within the stack. |
+| `overcicle` | - | Open overview when closed; while it is open, each trigger cycles focus to the next window on the current monitor. |
 | `focuslast` | - | Focus the previously active window. |
 | `switcher` | `next/prev` | Open or cycle the all-tag, all-monitor thumbnail switcher. Releasing any modifier key selects. |
 | `exchange_client` | `left/right/up/down` | Swap window with neighbor in direction. |

--- a/docs/window-management/overview.md
+++ b/docs/window-management/overview.md
@@ -21,9 +21,9 @@ description: Configure the overview mode for window navigation.
 - `hotarea_corner` — Corner that triggers the hot area (0: top-left, 1: top-right, 2: bottom-left, 3: bottom-right).
 - `jump_labels` — Defines the ordered characters used for jump hints when in overview jump mode. Each visible window is assigned a label in this order, and pressing the corresponding key jumps to that window. The number of labels limits how many windows can be assigned hints at once.
 
-[`overcicle`](/docs/bindings/keys#focus--movement) opens overview; while
-overview is open, each trigger cycles focus to the next window on the current
-monitor. Release a modifier key or run `toggleoverview` to close it.
+To cycle through windows, use the
+[`switcher`](/docs/bindings/keys#focus--movement) command; release a modifier
+key to select.
 
 ### Mouse Interaction in Overview
 

--- a/docs/window-management/overview.md
+++ b/docs/window-management/overview.md
@@ -10,7 +10,6 @@ description: Configure the overview mode for window navigation.
 | `hotarea_size` | integer | `10` | Hot area size in pixels. |
 | `enable_hotarea` | integer | `0` | Enable hot areas (0: disable, 1: enable). |
 | `hotarea_corner` | integer | `2` | Hot area corner (0: top-left, 1: top-right, 2: bottom-left, 3: bottom-right). |
-| `ov_tab_mode` | integer | `1` | Overview tab mode (0: disable, 1: enable). |
 | `overviewgappi` | integer | `5` | Inner gap in overview mode. |
 | `overviewgappo` | integer | `30` | Outer gap in overview mode. |
 | `jump_labels` | string | `HJKLASDFGQWERTYUIOPZXCVBNM` | Character sequence used for jump hints in overview mode. |
@@ -20,8 +19,11 @@ description: Configure the overview mode for window navigation.
 - `enable_hotarea` — Toggles overview when the cursor enters the configured corner.
 - `hotarea_size` — Size of the hot area trigger zone in pixels.
 - `hotarea_corner` — Corner that triggers the hot area (0: top-left, 1: top-right, 2: bottom-left, 3: bottom-right).
-- `ov_tab_mode` — Circles focus through windows in overview; releasing the mod key exits overview.
 - `jump_labels` — Defines the ordered characters used for jump hints when in overview jump mode. Each visible window is assigned a label in this order, and pressing the corresponding key jumps to that window. The number of labels limits how many windows can be assigned hints at once.
+
+[`overcicle`](/docs/bindings/keys#focus--movement) opens overview; while
+overview is open, each trigger cycles focus to the next window on the current
+monitor. Release a modifier key or run `toggleoverview` to close it.
 
 ### Mouse Interaction in Overview
 

--- a/docs/window-management/overview.md
+++ b/docs/window-management/overview.md
@@ -11,7 +11,6 @@ description: Configure the overview mode for window navigation.
 | `enable_hotarea` | integer | `0` | Enable hot areas (0: disable, 1: enable). |
 | `hotarea_corner` | integer | `2` | Hot area corner (0: top-left, 1: top-right, 2: bottom-left, 3: bottom-right). |
 | `ov_tab_mode` | integer | `1` | Overview tab mode (0: disable, 1: enable). |
-| `ov_tab_mode_launch_next` | integer | `0` | Launch next window in overview tab mode when trigger (0: disable, 1: enable). |
 | `overviewgappi` | integer | `5` | Inner gap in overview mode. |
 | `overviewgappo` | integer | `30` | Outer gap in overview mode. |
 | `jump_labels` | string | `HJKLASDFGQWERTYUIOPZXCVBNM` | Character sequence used for jump hints in overview mode. |
@@ -22,7 +21,6 @@ description: Configure the overview mode for window navigation.
 - `hotarea_size` — Size of the hot area trigger zone in pixels.
 - `hotarea_corner` — Corner that triggers the hot area (0: top-left, 1: top-right, 2: bottom-left, 3: bottom-right).
 - `ov_tab_mode` — Circles focus through windows in overview; releasing the mod key exits overview.
-- `ov_tab_mode_launch_next` — Launch next window in overview tab mode when trigger (0: disable, 1: enable).
 - `jump_labels` — Defines the ordered characters used for jump hints when in overview jump mode. Each visible window is assigned a label in this order, and pressing the corresponding key jumps to that window. The number of labels limits how many windows can be assigned hints at once.
 
 ### Mouse Interaction in Overview

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('mango', ['c'],
-  version : '0.16.1',
+  version : '0.16.2',
 )
 
 subdir('protocols')

--- a/nix/hm-modules.nix
+++ b/nix/hm-modules.nix
@@ -32,7 +32,7 @@ in
       systemd = {
         enable = mkOption {
           type = types.bool;
-          default = pkgs.stdenv.isLinux;
+          default = pkgs.stdenv.hostPlatform.isLinux;
           example = false;
           description = ''
             Whether to enable {file}`mango-session.target` on

--- a/src/animation/client.h
+++ b/src/animation/client.h
@@ -1482,12 +1482,8 @@ void resize_apply(Client *c, struct wlr_box geo, ResizeOpts opts) {
 			!c->animation.overview_enter_anim_set)
 			c->animation.overining = false;
 
-		/* 设置进入放大动画：ov_tab 所有窗口，其余除 sel 外 */
-		bool is_ov_tab = config.ov_tab_mode && !c->mon->is_jump_mode &&
-						 !c->mon->ov_normal_mode;
-		if (config.animations && c->mon->isoverview &&
-			((is_ov_tab && config.ov_tab_mode_launch_next) ||
-			 c != c->mon->sel) &&
+		/* 设置进入放大动画：除 sel 外的窗口 */
+		if (config.animations && c->mon->isoverview && c != c->mon->sel &&
 			c->animation.action == OVERVIEW &&
 			!c->animation.overview_enter_anim_set) {
 			c->animation.overview_enter_anim_set = true;

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -351,7 +351,6 @@ typedef struct {
 	int32_t hotarea_corner;
 	int32_t enable_hotarea;
 	int32_t ov_tab_mode;
-	int32_t ov_tab_mode_launch_next;
 
 	int32_t overviewgappi;
 	int32_t overviewgappo;
@@ -1982,8 +1981,6 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 		config->enable_hotarea = atoi(value);
 	} else if (strcmp(key, "ov_tab_mode") == 0) {
 		config->ov_tab_mode = atoi(value);
-	} else if (strcmp(key, "ov_tab_mode_launch_next") == 0) {
-		config->ov_tab_mode_launch_next = atoi(value);
 	} else if (strcmp(key, "overviewgappi") == 0) {
 		config->overviewgappi = atoi(value);
 	} else if (strcmp(key, "overviewgappo") == 0) {
@@ -4289,8 +4286,6 @@ void override_config(void) {
 	config.hotarea_corner = CLAMP_INT(config.hotarea_corner, 0, 3);
 	config.enable_hotarea = CLAMP_INT(config.enable_hotarea, 0, 1);
 	config.ov_tab_mode = CLAMP_INT(config.ov_tab_mode, 0, 1);
-	config.ov_tab_mode_launch_next =
-		CLAMP_INT(config.ov_tab_mode_launch_next, 0, 1);
 	config.overviewgappi = CLAMP_INT(config.overviewgappi, 0, 1000);
 	config.overviewgappo = CLAMP_INT(config.overviewgappo, 0, 1000);
 	config.xwayland_persistence = CLAMP_INT(config.xwayland_persistence, 0, 1);
@@ -4485,7 +4480,6 @@ void set_value_default() {
 	config.numlockon = 0;
 	config.capslock = 0;
 	config.ov_tab_mode = 1;
-	config.ov_tab_mode_launch_next = 0;
 	config.hotarea_size = 10;
 	config.hotarea_corner = BOTTOM_LEFT;
 	config.enable_hotarea = 0;

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -1214,8 +1214,6 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 	if (strcmp(func_name, "focusstack") == 0) {
 		func = focusstack;
 		(*arg).i = parse_circle_direction(arg_value);
-	} else if (strcmp(func_name, "overcicle") == 0) {
-		func = overcicle;
 	} else if (strcmp(func_name, "groupfocus") == 0) {
 		func = groupfocus;
 		(*arg).i = parse_circle_direction(arg_value);
@@ -1299,7 +1297,25 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 		func = focuslast;
 	} else if (strcmp(func_name, "switcher") == 0) {
 		func = switcher;
-		(*arg).i = parse_circle_direction(arg_value);
+		if (strcmp(arg_value, "all_next") == 0) {
+			(*arg).i = NEXT;
+			(*arg).i2 = SW_ALL_MON;
+		} else if (strcmp(arg_value, "all_prev") == 0) {
+			(*arg).i = PREV;
+			(*arg).i2 = SW_ALL_MON;
+		} else if (strcmp(arg_value, "all_tag_next") == 0) {
+			(*arg).i = NEXT;
+			(*arg).i2 = SW_ALL_TAG;
+		} else if (strcmp(arg_value, "all_tag_prev") == 0) {
+			(*arg).i = PREV;
+			(*arg).i2 = SW_ALL_TAG;
+		} else if (strcmp(arg_value, "prev") == 0) {
+			(*arg).i = PREV;
+			(*arg).i2 = SW_CURRENT_TAG;
+		} else {
+			(*arg).i = NEXT;
+			(*arg).i2 = SW_CURRENT_TAG;
+		}
 	} else if (strcmp(func_name, "toggle_trackpad_enable") == 0) {
 		func = toggle_trackpad_enable;
 	} else if (strcmp(func_name, "setoption") == 0) {

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -575,6 +575,31 @@ void trim_whitespace(char *str) {
 	}
 }
 
+// remove comment, support double quote inside "#xxx" or '#xxx' not be treated
+// as comment
+void remove_comment(char *str) {
+	if (str == NULL || *str == '\0')
+		return;
+
+	char quote_char = '\0';
+
+	for (char *p = str; *p != '\0'; p++) {
+		if (quote_char == '\0') {
+			if (*p == '\'' || *p == '"') {
+				quote_char = *p;
+			} else if (*p == '#' && p > str &&
+					   isspace((unsigned char)*(p - 1))) {
+				*p = '\0';
+				return;
+			}
+		} else {
+			if (*p == quote_char) {
+				quote_char = '\0';
+			}
+		}
+	}
+}
+
 int32_t parse_double_array(const char *input, double *output,
 						   int32_t max_count) {
 	char *dup = strdup(input);
@@ -3509,13 +3534,18 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 }
 
 bool parse_config_line(Config *config, const char *line, int line_number) {
+	char processed_line[512];
+	strncpy(processed_line, line, sizeof(processed_line) - 1);
+	processed_line[sizeof(processed_line) - 1] = '\0';
+
+	remove_comment(processed_line);
+
 	char key[256], value[256];
-	if (sscanf(line, "%255[^=]=%255[^\n]", key, value) != 2) {
+	if (sscanf(processed_line, "%255[^=]=%255[^\n]", key, value) != 2) {
 		mango_error(false, WLR_ERROR, "Invalid line format: %s", line);
 		return false;
 	}
 
-	// Then trim each part separately
 	trim_whitespace(key);
 	trim_whitespace(value);
 

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -702,6 +702,7 @@ static void set_binding_keymode(Config *config, char mode[28],
 
 int32_t parse_circle_direction(const char *str) {
 	// 将输入字符串转换为小写
+
 	char lowerStr[10];
 	int32_t i = 0;
 	while (str[i] && i < 9) {
@@ -1298,6 +1299,9 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 		func = centerwin;
 	} else if (strcmp(func_name, "focuslast") == 0) {
 		func = focuslast;
+	} else if (strcmp(func_name, "switcher") == 0) {
+		func = switcher;
+		(*arg).i = parse_circle_direction(arg_value);
 	} else if (strcmp(func_name, "toggle_trackpad_enable") == 0) {
 		func = toggle_trackpad_enable;
 	} else if (strcmp(func_name, "setoption") == 0) {

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -350,7 +350,6 @@ typedef struct {
 	int32_t hotarea_size;
 	int32_t hotarea_corner;
 	int32_t enable_hotarea;
-	int32_t ov_tab_mode;
 
 	int32_t overviewgappi;
 	int32_t overviewgappo;
@@ -1215,6 +1214,8 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 	if (strcmp(func_name, "focusstack") == 0) {
 		func = focusstack;
 		(*arg).i = parse_circle_direction(arg_value);
+	} else if (strcmp(func_name, "overcicle") == 0) {
+		func = overcicle;
 	} else if (strcmp(func_name, "groupfocus") == 0) {
 		func = groupfocus;
 		(*arg).i = parse_circle_direction(arg_value);
@@ -1263,10 +1264,8 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 		(*arg).v = has_name ? strdup(arg_value2) : NULL;
 	} else if (strcmp(func_name, "toggleoverview") == 0) {
 		func = toggleoverview;
-		(*arg).i = atoi(arg_value);
 	} else if (strcmp(func_name, "togglejump") == 0) {
 		func = togglejump;
-		(*arg).i = atoi(arg_value);
 	} else if (strcmp(func_name, "set_proportion") == 0) {
 		func = set_proportion;
 		(*arg).f = atof(arg_value);
@@ -1979,8 +1978,6 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 		config->hotarea_corner = atoi(value);
 	} else if (strcmp(key, "enable_hotarea") == 0) {
 		config->enable_hotarea = atoi(value);
-	} else if (strcmp(key, "ov_tab_mode") == 0) {
-		config->ov_tab_mode = atoi(value);
 	} else if (strcmp(key, "overviewgappi") == 0) {
 		config->overviewgappi = atoi(value);
 	} else if (strcmp(key, "overviewgappo") == 0) {
@@ -4285,7 +4282,6 @@ void override_config(void) {
 	config.hotarea_size = CLAMP_INT(config.hotarea_size, 1, 1000);
 	config.hotarea_corner = CLAMP_INT(config.hotarea_corner, 0, 3);
 	config.enable_hotarea = CLAMP_INT(config.enable_hotarea, 0, 1);
-	config.ov_tab_mode = CLAMP_INT(config.ov_tab_mode, 0, 1);
 	config.overviewgappi = CLAMP_INT(config.overviewgappi, 0, 1000);
 	config.overviewgappo = CLAMP_INT(config.overviewgappo, 0, 1000);
 	config.xwayland_persistence = CLAMP_INT(config.xwayland_persistence, 0, 1);
@@ -4479,7 +4475,6 @@ void set_value_default() {
 	config.log_level = WLR_ERROR;
 	config.numlockon = 0;
 	config.capslock = 0;
-	config.ov_tab_mode = 1;
 	config.hotarea_size = 10;
 	config.hotarea_corner = BOTTOM_LEFT;
 	config.enable_hotarea = 0;

--- a/src/dispatch/bind_declare.h
+++ b/src/dispatch/bind_declare.h
@@ -6,6 +6,7 @@ void focus_window_or_workspace(const Arg *arg);
 void groupjoin(const Arg *arg);
 void groupleave(const Arg *arg);
 void toggleoverview(const Arg *arg);
+void switcher(const Arg *arg);
 void togglehdr(const Arg *arg);
 void togglejump(const Arg *arg);
 void set_proportion(const Arg *arg);

--- a/src/dispatch/bind_declare.h
+++ b/src/dispatch/bind_declare.h
@@ -44,6 +44,7 @@ void toggleglobal(const Arg *arg);
 void incnmaster(const Arg *arg);
 void focusmon(const Arg *arg);
 void focusstack(const Arg *arg);
+void overcicle(const Arg *arg);
 void groupfocus(const Arg *arg);
 void chvt(const Arg *arg);
 void reload_config(const Arg *arg);

--- a/src/dispatch/bind_declare.h
+++ b/src/dispatch/bind_declare.h
@@ -44,7 +44,6 @@ void toggleglobal(const Arg *arg);
 void incnmaster(const Arg *arg);
 void focusmon(const Arg *arg);
 void focusstack(const Arg *arg);
-void overcicle(const Arg *arg);
 void groupfocus(const Arg *arg);
 void chvt(const Arg *arg);
 void reload_config(const Arg *arg);

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -384,115 +384,6 @@ void focusstack(const Arg *arg) {
 	return;
 }
 
-static bool overcicle_candidate(Client *c, Monitor *m) {
-	return c && c->mon == m && !c->isunglobal && !c->iskilling &&
-		   !c->isminimized && !client_is_unmanaged(c) &&
-		   !client_is_x11_popup(c) && client_surface(c) &&
-		   client_surface(c)->mapped && VISIBLEON(c, m);
-}
-
-static void overcicle_clear(Monitor *m) {
-	if (!m)
-		return;
-	free(m->overcicle_clients);
-	m->overcicle_clients = NULL;
-	m->overcicle_count = 0;
-	m->overcicle_index = 0;
-}
-
-/* 打开 overview 时按 fstack/flink 顺序建立循环快照：
- * 当前焦点在第 0 位，上一次切换的焦点在第 1 位；
- * 首次触发即切到第 1 位，之后单向遍历全部窗口 */
-static void overcicle_build(Monitor *m) {
-	overcicle_clear(m);
-	if (!m)
-		return;
-
-	Client *c;
-	int n = 0;
-	wl_list_for_each(c, &fstack, flink) {
-		if (overcicle_candidate(c, m))
-			n++;
-	}
-	if (n <= 0)
-		return;
-
-	m->overcicle_clients = ecalloc(n, sizeof(Client *));
-	n = 0;
-	wl_list_for_each(c, &fstack, flink) {
-		if (overcicle_candidate(c, m))
-			m->overcicle_clients[n++] = c;
-	}
-	m->overcicle_count = n;
-	m->overcicle_index = 0;
-}
-
-/* 窗口销毁时从快照中移除，避免悬挂指针 */
-static void overcicle_remove_client(Client *c) {
-	if (!c || !c->mon || !c->mon->overcicle_clients ||
-		c->mon->overcicle_count <= 0)
-		return;
-
-	Monitor *m = c->mon;
-	int i;
-	for (i = 0; i < m->overcicle_count; i++) {
-		if (m->overcicle_clients[i] == c)
-			break;
-	}
-	if (i == m->overcicle_count)
-		return;
-
-	if (m->overcicle_index > i)
-		m->overcicle_index--;
-	memmove(&m->overcicle_clients[i], &m->overcicle_clients[i + 1],
-			(m->overcicle_count - i - 1) * sizeof(Client *));
-	m->overcicle_count--;
-	if (m->overcicle_count <= 0) {
-		overcicle_clear(m);
-		return;
-	}
-	if (m->overcicle_index >= m->overcicle_count)
-		m->overcicle_index = m->overcicle_count - 1;
-}
-
-/* overcicle: 打开/循环 overview（居中 tab 布局）
- * - 未进入 overview：进入 overview，并按 flink 建立循环快照
- * - 已在 overview 中：每次触发单向向前遍历快照（首次切到上一次切换的焦点） */
-void overcicle(const Arg *arg) {
-	if (!selmon || grabc)
-		return;
-
-	Client *sel = arg->tc ? arg->tc : selmon->sel;
-
-	if (selmon->isoverview && !selmon->is_jump_mode &&
-		!selmon->ov_normal_mode && sel) {
-		/* 快照缺失时（如由 toggleoverview 等进入）先按 flink 建立 */
-		if (selmon->overcicle_count <= 0)
-			overcicle_build(selmon);
-		if (selmon->overcicle_count <= 0)
-			return;
-
-		selmon->overcicle_index =
-			(selmon->overcicle_index + 1 + selmon->overcicle_count) %
-			selmon->overcicle_count;
-
-		Client *tc = selmon->overcicle_clients[selmon->overcicle_index];
-		focusclient(tc, 1);
-		if (config.warpcursor)
-			warp_cursor(tc);
-
-		/* 切换焦点后重排，让 tab 布局跟随焦点 */
-		arrange(selmon, true, false);
-		return;
-	}
-
-	/* 未进入 overview：打开（tab 布局），并按 flink 建立循环快照 */
-	toggleoverview(arg);
-
-	if (selmon && selmon->isoverview)
-		overcicle_build(selmon);
-}
-
 void groupfocus(const Arg *arg) {
 	Client *c = arg->tc ? arg->tc : selmon->sel;
 	if (!c || !c->mon)
@@ -2035,10 +1926,8 @@ void toggleoverview(const Arg *arg) {
 	uint32_t target;
 	uint32_t visible_client_number = 0;
 
-	if (!selmon->isoverview) {
-		overcicle_clear(selmon);
-		if (selmon->is_jump_mode)
-			finish_jump_mode(selmon);
+	if (!selmon->isoverview && selmon->is_jump_mode) {
+		finish_jump_mode(selmon);
 	}
 
 	if (selmon->isoverview) {

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -384,6 +384,115 @@ void focusstack(const Arg *arg) {
 	return;
 }
 
+static bool overcicle_candidate(Client *c, Monitor *m) {
+	return c && c->mon == m && !c->isunglobal && !c->iskilling &&
+		   !c->isminimized && !client_is_unmanaged(c) &&
+		   !client_is_x11_popup(c) && client_surface(c) &&
+		   client_surface(c)->mapped && VISIBLEON(c, m);
+}
+
+static void overcicle_clear(Monitor *m) {
+	if (!m)
+		return;
+	free(m->overcicle_clients);
+	m->overcicle_clients = NULL;
+	m->overcicle_count = 0;
+	m->overcicle_index = 0;
+}
+
+/* 打开 overview 时按 fstack/flink 顺序建立循环快照：
+ * 当前焦点在第 0 位，上一次切换的焦点在第 1 位；
+ * 首次触发即切到第 1 位，之后单向遍历全部窗口 */
+static void overcicle_build(Monitor *m) {
+	overcicle_clear(m);
+	if (!m)
+		return;
+
+	Client *c;
+	int n = 0;
+	wl_list_for_each(c, &fstack, flink) {
+		if (overcicle_candidate(c, m))
+			n++;
+	}
+	if (n <= 0)
+		return;
+
+	m->overcicle_clients = ecalloc(n, sizeof(Client *));
+	n = 0;
+	wl_list_for_each(c, &fstack, flink) {
+		if (overcicle_candidate(c, m))
+			m->overcicle_clients[n++] = c;
+	}
+	m->overcicle_count = n;
+	m->overcicle_index = 0;
+}
+
+/* 窗口销毁时从快照中移除，避免悬挂指针 */
+static void overcicle_remove_client(Client *c) {
+	if (!c || !c->mon || !c->mon->overcicle_clients ||
+		c->mon->overcicle_count <= 0)
+		return;
+
+	Monitor *m = c->mon;
+	int i;
+	for (i = 0; i < m->overcicle_count; i++) {
+		if (m->overcicle_clients[i] == c)
+			break;
+	}
+	if (i == m->overcicle_count)
+		return;
+
+	if (m->overcicle_index > i)
+		m->overcicle_index--;
+	memmove(&m->overcicle_clients[i], &m->overcicle_clients[i + 1],
+			(m->overcicle_count - i - 1) * sizeof(Client *));
+	m->overcicle_count--;
+	if (m->overcicle_count <= 0) {
+		overcicle_clear(m);
+		return;
+	}
+	if (m->overcicle_index >= m->overcicle_count)
+		m->overcicle_index = m->overcicle_count - 1;
+}
+
+/* overcicle: 打开/循环 overview（居中 tab 布局）
+ * - 未进入 overview：进入 overview，并按 flink 建立循环快照
+ * - 已在 overview 中：每次触发单向向前遍历快照（首次切到上一次切换的焦点） */
+void overcicle(const Arg *arg) {
+	if (!selmon || grabc)
+		return;
+
+	Client *sel = arg->tc ? arg->tc : selmon->sel;
+
+	if (selmon->isoverview && !selmon->is_jump_mode &&
+		!selmon->ov_normal_mode && sel) {
+		/* 快照缺失时（如由 toggleoverview 等进入）先按 flink 建立 */
+		if (selmon->overcicle_count <= 0)
+			overcicle_build(selmon);
+		if (selmon->overcicle_count <= 0)
+			return;
+
+		selmon->overcicle_index =
+			(selmon->overcicle_index + 1 + selmon->overcicle_count) %
+			selmon->overcicle_count;
+
+		Client *tc = selmon->overcicle_clients[selmon->overcicle_index];
+		focusclient(tc, 1);
+		if (config.warpcursor)
+			warp_cursor(tc);
+
+		/* 切换焦点后重排，让 tab 布局跟随焦点 */
+		arrange(selmon, true, false);
+		return;
+	}
+
+	/* 未进入 overview：打开（tab 布局），并按 flink 建立循环快照 */
+	toggleoverview(arg);
+
+	if (selmon && selmon->isoverview)
+		overcicle_build(selmon);
+}
+
 void groupfocus(const Arg *arg) {
 	Client *c = arg->tc ? arg->tc : selmon->sel;
 	if (!c || !c->mon)
@@ -1922,19 +2031,14 @@ void toggleoverview(const Arg *arg) {
 
 	Client *sel = arg->tc ? arg->tc : selmon->sel;
 
-	if (selmon->isoverview && config.ov_tab_mode && !selmon->is_jump_mode &&
-		!selmon->ov_normal_mode && arg->i != 1 && sel) {
-		focusstack(&(Arg){.i = 1});
-		arrange(selmon, true, false);
-		return;
-	}
-
 	selmon->isoverview ^= 1;
 	uint32_t target;
 	uint32_t visible_client_number = 0;
 
-	if (!selmon->isoverview && selmon->is_jump_mode) {
-		finish_jump_mode(selmon);
+	if (!selmon->isoverview) {
+		overcicle_clear(selmon);
+		if (selmon->is_jump_mode)
+			finish_jump_mode(selmon);
 	}
 
 	if (selmon->isoverview) {
@@ -1977,9 +2081,8 @@ void toggleoverview(const Arg *arg) {
 				!client_is_x11_popup(c) && !c->isunglobal && !c->isminimized &&
 				client_surface(c)->mapped) {
 				c->animation.overining = true;
-				if (config.ov_tab_mode && !selmon->is_jump_mode &&
-					!selmon->ov_normal_mode)
-					/* ov_tab：先跳过 view 排布，等 focusstack 后再设 */
+				if (!selmon->is_jump_mode && !selmon->ov_normal_mode)
+					/* tab 布局：先跳过 view 排布，进入后统一重排时再设 */
 					c->animation.overview_enter_anim_set = true;
 				else
 					/* 其余模式：view 排布时设置放大 */
@@ -2002,8 +2105,8 @@ void toggleoverview(const Arg *arg) {
 
 	view(&(Arg){.ui = target}, false);
 
-	/* ov_tab：进入后重排 */
-	if (selmon->isoverview && config.ov_tab_mode && !selmon->is_jump_mode &&
+	/* tab 布局：进入后重排 */
+	if (selmon->isoverview && !selmon->is_jump_mode &&
 		!selmon->ov_normal_mode) {
 
 		Client *cc = NULL;

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -2002,13 +2002,9 @@ void toggleoverview(const Arg *arg) {
 
 	view(&(Arg){.ui = target}, false);
 
-	/* ov_tab：进入后自动切到下一焦点并重排 */
+	/* ov_tab：进入后重排 */
 	if (selmon->isoverview && config.ov_tab_mode && !selmon->is_jump_mode &&
 		!selmon->ov_normal_mode) {
-
-		if (config.ov_tab_mode_launch_next) {
-			focusstack(&(Arg){.i = 1});
-		}
 
 		Client *cc = NULL;
 		wl_list_for_each(cc, &clients, link) {

--- a/src/ext-protocol/ext-workspace.h
+++ b/src/ext-protocol/ext-workspace.h
@@ -25,7 +25,7 @@ void goto_workspace(struct workspace *target) {
 	uint32_t tag;
 	tag = 1 << (target->tag - 1);
 	if (target->tag == 0) {
-		toggleoverview(&(Arg){.i = -1});
+		toggleoverview(&(Arg){0});
 		return;
 	} else {
 		view(&(Arg){.ui = tag}, true);

--- a/src/input/keyboard.h
+++ b/src/input/keyboard.h
@@ -499,13 +499,12 @@ void keypress(struct wl_listener *listener, void *data) {
 
 	wlr_idle_notifier_v1_notify_activity(idle_notifier, seat);
 
-	// ov tab mode detect moe key release
-	if (config.ov_tab_mode && selmon && !selmon->is_jump_mode &&
-		selmon->isoverview && selmon->sel && !locked &&
-		!group->virtual_keyboard &&
+	// overview tab mode detect mod key release
+	if (selmon && !selmon->is_jump_mode && selmon->isoverview && selmon->sel &&
+		!locked && !group->virtual_keyboard &&
 		event->state == WL_KEYBOARD_KEY_STATE_RELEASED &&
 		ISMODEKEYCODE(keycode)) {
-		toggleoverview(&(Arg){.i = 1});
+		toggleoverview(&(Arg){0});
 	}
 
 	if (switcher_is_active()) {
@@ -556,7 +555,7 @@ void keypress(struct wl_listener *listener, void *data) {
 		event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 		for (i = 0; i < nsyms; i++) {
 			if (syms[i] == XKB_KEY_Escape) {
-				togglejump(&(Arg){.i = 0});
+				togglejump(&(Arg){0});
 				return;
 			}
 			// keysym 转字符，与 jump_labels 匹配（字母忽略大小写）
@@ -572,7 +571,7 @@ void keypress(struct wl_listener *listener, void *data) {
 					 toupper((unsigned char)c_char) ==
 						 toupper((unsigned char)c->jump_char))) {
 					focusclient(c, 1);
-					toggleoverview(&(Arg){.i = 1});
+					toggleoverview(&(Arg){0});
 					return;
 				}
 			}

--- a/src/input/keyboard.h
+++ b/src/input/keyboard.h
@@ -508,6 +508,18 @@ void keypress(struct wl_listener *listener, void *data) {
 		toggleoverview(&(Arg){.i = 1});
 	}
 
+	if (switcher_is_active()) {
+		if (locked) {
+			switcher_close();
+		} else if (!group->virtual_keyboard &&
+				   event->state == WL_KEYBOARD_KEY_STATE_RELEASED &&
+				   ISMODEKEYCODE(keycode)) {
+			switcher_commit();
+			group->nsyms = 0;
+			wl_event_source_timer_update(group->key_repeat_source, 0);
+		}
+	}
+
 	if (config.cursor_hide_on_keypress && !cursor_hidden &&
 		event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 		hidecursor(NULL);

--- a/src/input/pointer.h
+++ b/src/input/pointer.h
@@ -60,7 +60,7 @@ void toggle_hotarea(int32_t x_root, int32_t y_root) {
 
 	if (config.enable_hotarea == 1 && selmon->is_in_hotarea == 0 &&
 		in_hotarea) {
-		/* 热区进入：忽略 ov_tab_mode */
+		/* 热区进入：使用普通网格布局 */
 		selmon->ov_normal_mode = 1;
 		toggleoverview(&arg);
 		selmon->is_in_hotarea = 1;
@@ -475,7 +475,7 @@ bool handle_buttonpress(struct wlr_pointer_button_event *event) {
 
 		// overview模式下鼠标左键跳转，右键关闭窗口
 		if (selmon && selmon->isoverview && event->button == BTN_LEFT && c) {
-			toggleoverview(&(Arg){.i = 1});
+			toggleoverview(&(Arg){0});
 			return true;
 		}
 
@@ -1027,8 +1027,7 @@ void pointerfocus(Client *c, struct wlr_surface *surface, double sx, double sy,
 	struct timespec now;
 
 	if (config.sloppyfocus && !start_drag_window && c && time && c->scene &&
-		c->scene->node.enabled &&
-		(!c->mon || !c->mon->isoverview || !config.ov_tab_mode) &&
+		c->scene->node.enabled && (!c->mon || !c->mon->isoverview) &&
 		!c->animation.tagining &&
 		(surface != seat->pointer_state.focused_surface ||
 		 (selmon && selmon->isoverview && selmon->sel != c)) &&

--- a/src/input/pointer.h
+++ b/src/input/pointer.h
@@ -441,6 +441,19 @@ bool handle_buttonpress(struct wlr_pointer_button_event *event) {
 		if (locked)
 			break;
 
+		if (switcher_is_active() &&
+			(event->button == BTN_LEFT || event->button == BTN_RIGHT)) {
+			Client *switcher_c = switcher_client_at(cursor->x, cursor->y);
+			if (!switcher_c)
+				switcher_close();
+			else if (event->button == BTN_LEFT)
+				switcher_commit_client(switcher_c);
+			else
+				pending_kill_client(switcher_c);
+			wlr_seat_pointer_notify_clear_focus(seat);
+			return true;
+		}
+
 		xytonode(cursor->x, cursor->y, &surface, NULL, NULL, &gb, NULL, NULL);
 		if (toplevel_from_wlr_surface(surface, &c, &l) >= 0) {
 			if (c && c->scene && c->scene->node.enabled &&

--- a/src/ipc/ipc.h
+++ b/src/ipc/ipc.h
@@ -556,7 +556,8 @@ static void handle_command(int client_fd, const char *cmd_raw) {
 		if (client_id > 0) {
 			arg.tc = client_by_id((uint32_t)client_id);
 			if (arg.tc == NULL)
-				return send_static_json(client_fd, "{\"error\":\"no client found\"}\n");
+				return send_static_json(client_fd,
+										"{\"error\":\"no client found\"}\n");
 		}
 
 		if (func) {

--- a/src/layout/overview.h
+++ b/src/layout/overview.h
@@ -262,7 +262,7 @@ void overview_scale(Monitor *m) {
 	free(feas);
 }
 
-// ov_tab_mode 的 overview 布局：聚焦窗口居中（约一半屏宽），其余窗口分列两侧
+// overview 布局：聚焦窗口居中（约一半屏宽），其余窗口分列两侧
 static void overview_layout_column(Monitor *m, Client **items, int cnt, float x,
 								   float top, float col_w, float col_h,
 								   float gap) {
@@ -494,7 +494,7 @@ void finish_jump_mode(Monitor *m) {
 }
 
 void overview(Monitor *m) {
-	if (config.ov_tab_mode && !m->is_jump_mode && !m->ov_normal_mode) {
+	if (!m->is_jump_mode && !m->ov_normal_mode) {
 		overview_scale_tab(m);
 	} else {
 		overview_scale(m);

--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -689,7 +689,8 @@ bool check_hit_no_border(Client *c) {
 	}
 
 	if (config.no_border_when_single && c && c->mon &&
-		c->mon->visible_clients == 1) {
+		((ISSCROLLTILED(c) && c->mon->visible_fake_tiling_clients == 1) ||
+		 c->mon->visible_clients == 1)) {
 		hit_no_border = true;
 	}
 	return hit_no_border;

--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -2028,6 +2028,7 @@ void unmapnotify(struct wl_listener *listener, void *data) {
 	Client *nextfocus = NULL;
 	c->iskilling = 1;
 	switcher_remove_client(c);
+	overcicle_remove_client(c);
 	struct ScrollerStackNode *target_node =
 		c->mon ? find_scroller_node(
 					 c->mon->pertag->scroller_state[c->mon->pertag->curtag], c)
@@ -2209,6 +2210,7 @@ destroynotify(struct wl_listener *listener, void *data) {
 		wl_list_remove(&c->set_decoration_mode.link);
 	}
 	switcher_remove_client(c);
+	overcicle_remove_client(c);
 	free(c);
 }
 

--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -1784,6 +1784,11 @@ void init_client_properties(Client *c) {
 	c->animation.overview_enter_anim_set = false;
 	c->animation.tagouting = false;
 	c->animation.tagouted = false;
+
+	c->image_capture_scene_surface = NULL;
+	c->image_capture_tree = NULL;
+	c->image_capture_source = NULL;
+
 	wl_list_init(&c->link);
 	wl_list_init(&c->flink);
 }
@@ -1842,8 +1847,14 @@ mapnotify(struct wl_listener *listener, void *data) {
 	c->ext_foreign_toplevel = wlr_ext_foreign_toplevel_handle_v1_create(
 		foreign_toplevel_list, &foreign_toplevel_state);
 	c->ext_foreign_toplevel->data = c;
-	c->image_capture_scene_surface = wlr_scene_surface_create(
-		&c->image_capture_scene->tree, client_surface(c));
+
+	if (client_is_x11(c)) {
+		c->image_capture_scene_surface = wlr_scene_surface_create(
+			&c->image_capture_scene->tree, client_surface(c));
+	} else {
+		c->image_capture_tree = wlr_scene_xdg_surface_create(
+			&c->image_capture_scene->tree, c->surface.xdg);
+	}
 
 	/* Handle unmanaged clients first so we can return prior create borders
 	 */
@@ -2154,16 +2165,11 @@ void unmapnotify(struct wl_listener *listener, void *data) {
 		c->group_bar = NULL;
 	}
 
-	if (c->image_capture_tree) {
-		wlr_scene_node_destroy(&c->image_capture_tree->node);
-		c->image_capture_tree = NULL;
-	}
 	if (c->image_capture_scene) {
 		wlr_scene_node_destroy(&c->image_capture_scene->tree.node);
 		c->image_capture_scene = NULL;
 	}
 
-	c->image_capture_source = NULL;
 	init_client_properties(c);
 
 	wlr_scene_node_destroy(&c->scene->node);

--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -2027,6 +2027,7 @@ void unmapnotify(struct wl_listener *listener, void *data) {
 	Monitor *m = NULL;
 	Client *nextfocus = NULL;
 	c->iskilling = 1;
+	switcher_close();
 	struct ScrollerStackNode *target_node =
 		c->mon ? find_scroller_node(
 					 c->mon->pertag->scroller_state[c->mon->pertag->curtag], c)

--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -2028,7 +2028,6 @@ void unmapnotify(struct wl_listener *listener, void *data) {
 	Client *nextfocus = NULL;
 	c->iskilling = 1;
 	switcher_remove_client(c);
-	overcicle_remove_client(c);
 	struct ScrollerStackNode *target_node =
 		c->mon ? find_scroller_node(
 					 c->mon->pertag->scroller_state[c->mon->pertag->curtag], c)
@@ -2210,7 +2209,6 @@ destroynotify(struct wl_listener *listener, void *data) {
 		wl_list_remove(&c->set_decoration_mode.link);
 	}
 	switcher_remove_client(c);
-	overcicle_remove_client(c);
 	free(c);
 }
 

--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -2027,7 +2027,7 @@ void unmapnotify(struct wl_listener *listener, void *data) {
 	Monitor *m = NULL;
 	Client *nextfocus = NULL;
 	c->iskilling = 1;
-	switcher_close();
+	switcher_remove_client(c);
 	struct ScrollerStackNode *target_node =
 		c->mon ? find_scroller_node(
 					 c->mon->pertag->scroller_state[c->mon->pertag->curtag], c)
@@ -2208,6 +2208,7 @@ destroynotify(struct wl_listener *listener, void *data) {
 		wl_list_remove(&c->destroy_decoration.link);
 		wl_list_remove(&c->set_decoration_mode.link);
 	}
+	switcher_remove_client(c);
 	free(c);
 }
 

--- a/src/manage/monitor.h
+++ b/src/manage/monitor.h
@@ -480,9 +480,6 @@ void createmon(struct wl_listener *listener, void *data) {
 	m->sel = NULL;
 	m->is_in_hotarea = 0;
 	m->ov_normal_mode = 0;
-	m->overcicle_clients = NULL;
-	m->overcicle_count = 0;
-	m->overcicle_index = 0;
 	m->m.x = INT32_MAX;
 	m->m.y = INT32_MAX;
 
@@ -668,8 +665,6 @@ void cleanupmon(struct wl_listener *listener, void *data) {
 	uint32_t i;
 
 	m->iscleanuping = true;
-
-	overcicle_clear(m);
 
 	/* m->layers[i] are intentionally not unlinked */
 	for (i = 0; i < LENGTH(m->layers); i++) {

--- a/src/manage/monitor.h
+++ b/src/manage/monitor.h
@@ -480,6 +480,9 @@ void createmon(struct wl_listener *listener, void *data) {
 	m->sel = NULL;
 	m->is_in_hotarea = 0;
 	m->ov_normal_mode = 0;
+	m->overcicle_clients = NULL;
+	m->overcicle_count = 0;
+	m->overcicle_index = 0;
 	m->m.x = INT32_MAX;
 	m->m.y = INT32_MAX;
 
@@ -666,6 +669,8 @@ void cleanupmon(struct wl_listener *listener, void *data) {
 
 	m->iscleanuping = true;
 
+	overcicle_clear(m);
+
 	/* m->layers[i] are intentionally not unlinked */
 	for (i = 0; i < LENGTH(m->layers); i++) {
 		wl_list_for_each_safe(l, tmp, &m->layers[i], link)
@@ -717,7 +722,7 @@ void closemon(Monitor *m) {
 	int32_t i = 0, nmons = wl_list_length(&mons);
 
 	if (m->isoverview) {
-		toggleoverview(&(Arg){.i = 1});
+		toggleoverview(&(Arg){0});
 	}
 
 	if (!nmons) {

--- a/src/mango.c
+++ b/src/mango.c
@@ -222,6 +222,7 @@ enum { UP, DOWN, LEFT, RIGHT, UNDIR }; /* smartmovewin */
 enum { NONE, OPEN, MOVE, CLOSE, TAG, FOCUS, OPAFADEIN, OPAFADEOUT, OVERVIEW };
 enum { UNFOLD, FOLD, INVALIDFOLD };
 enum { PREV, NEXT };
+enum { SW_CURRENT_TAG, SW_ALL_TAG, SW_ALL_MON }; /* switcher 候选范围 */
 enum { STATE_UNSPECIFIED = 0, STATE_ENABLED, STATE_DISABLED };
 enum { FORCE, UNFORCE };
 
@@ -616,10 +617,7 @@ struct Monitor {
 	int32_t isoverview;
 	int32_t is_jump_mode;
 	int32_t is_in_hotarea;
-	int32_t ov_normal_mode;		/* 热区进入时使用普通网格布局 */
-	Client **overcicle_clients; /* overcicle 快照：打开时按 flink 排序 */
-	int overcicle_count;
-	int overcicle_index;
+	int32_t ov_normal_mode; /* 热区进入时使用普通网格布局 */
 	int32_t only_sleep;
 	uint32_t visible_clients;
 	uint32_t visible_tiling_clients;

--- a/src/mango.c
+++ b/src/mango.c
@@ -1332,6 +1332,7 @@ static void ipc_notify_device_event(struct wlr_input_device *device);
 #include "layout/scroll.h"
 #include "layout/vertical.h"
 #include "overview/overview.h"
+#include "switcher/switcher.h"
 
 #include "manage/client.h"
 #include "input/keyboard.h"

--- a/src/mango.c
+++ b/src/mango.c
@@ -616,7 +616,10 @@ struct Monitor {
 	int32_t isoverview;
 	int32_t is_jump_mode;
 	int32_t is_in_hotarea;
-	int32_t ov_normal_mode; /* 热区进入时忽略 ov_tab_mode */
+	int32_t ov_normal_mode;		/* 热区进入时使用普通网格布局 */
+	Client **overcicle_clients; /* overcicle 快照：打开时按 flink 排序 */
+	int overcicle_count;
+	int overcicle_index;
 	int32_t only_sleep;
 	uint32_t visible_clients;
 	uint32_t visible_tiling_clients;

--- a/src/switcher/switcher.h
+++ b/src/switcher/switcher.h
@@ -39,6 +39,7 @@ static struct {
 	int count;
 	int index;
 	int tile_h;
+	int scope;
 } sw;
 
 static bool switcher_is_active(void) { return sw.tree != NULL; }
@@ -48,6 +49,11 @@ static bool switcher_candidate(Client *c) {
 		c->is_logic_hide || !client_surface(c) || !client_surface(c)->mapped ||
 		client_is_unmanaged(c) || client_is_x11_popup(c))
 		return false;
+
+	if (sw.scope == SW_CURRENT_TAG)
+		return c->mon == sw.mon && VISIBLEON(c, sw.mon);
+	if (sw.scope == SW_ALL_TAG)
+		return c->mon == sw.mon;
 	return (int32_t)c->tags > 0;
 }
 
@@ -381,7 +387,10 @@ static void switcher_remove_client(Client *c) {
 
 static void switcher_commit_client(Client *tc) {
 	switcher_close();
-	if (!switcher_candidate(tc))
+	if (!tc || !tc->mon || tc->iskilling || tc->isminimized || tc->isunglobal ||
+		tc->is_logic_hide || !client_surface(tc) ||
+		!client_surface(tc)->mapped || client_is_unmanaged(tc) ||
+		client_is_x11_popup(tc))
 		return;
 	if (!VISIBLEON(tc, tc->mon))
 		view_in_mon(&(Arg){.ui = get_tags_first_tag(tc->tags)}, true, tc->mon,
@@ -412,7 +421,7 @@ static Client *switcher_client_at(double lx, double ly) {
 	return NULL;
 }
 
-static void switcher_open(void) {
+static void switcher_open(int scope) {
 	Client *c;
 	Monitor *m;
 	int n = 0;
@@ -421,6 +430,10 @@ static void switcher_open(void) {
 		if (m->isoverview)
 			return;
 	}
+
+	sw.mon = selmon;
+	sw.scope = scope;
+
 	wl_list_for_each(c, &fstack, flink) {
 		if (switcher_candidate(c))
 			n++;
@@ -428,7 +441,6 @@ static void switcher_open(void) {
 	if (n == 0)
 		return;
 
-	sw.mon = selmon;
 	int max_row_w = (int)(sw.mon->m.width * SW_PANEL_FRAC) - 2 * SW_MARGIN;
 	int max_panel_h = (int)(sw.mon->m.height * SW_PANEL_FRAC);
 	// size against the widest allowed tile so the panel always fits
@@ -477,10 +489,17 @@ static void switcher_cycle(int dir) {
 
 void switcher(const Arg *arg) {
 	int dir = arg && arg->i == PREV ? -1 : 1;
+	int scope = arg ? arg->i2 : SW_CURRENT_TAG;
 	if (locked || !selmon || selmon->is_jump_mode)
 		return;
-	if (switcher_is_active())
-		switcher_cycle(dir);
-	else
-		switcher_open();
+	if (switcher_is_active()) {
+		if (scope != sw.scope) {
+			switcher_close();
+			switcher_open(scope);
+		} else {
+			switcher_cycle(dir);
+		}
+	} else {
+		switcher_open(scope);
+	}
 }

--- a/src/switcher/switcher.h
+++ b/src/switcher/switcher.h
@@ -1,0 +1,450 @@
+#define SW_PAD 6
+#define SW_GAP 14
+#define SW_MARGIN 28
+#define SW_PANEL_FRAC 0.8f
+#define SW_TILE_FRAC 0.25f
+#define SW_ASPECT_MIN (9.0f / 16.0f)
+#define SW_ASPECT_MAX (12.0f / 5.0f)
+
+static const float switcher_panel_color[4] = {0.09f, 0.09f, 0.11f, 0.92f};
+
+struct switcher_tile {
+	Client *c;
+	struct wlr_scene_tree *tree;
+	struct wlr_scene_rect *frame;
+	struct wlr_scene_tree *content;
+	struct wl_list surfaces; /* switcher_surface.link */
+	int cw;
+	int row;
+};
+
+struct switcher_surface {
+	struct switcher_tile *tile;
+	struct wlr_surface *surface;
+	struct wlr_scene_buffer *buffer;
+	int sx, sy;
+	bool is_root;
+	struct wl_listener commit;
+	struct wl_listener destroy;
+	struct wl_listener output_sample;
+	struct wl_listener frame_done;
+	struct wl_list link;
+};
+
+static struct {
+	Monitor *mon;
+	struct wlr_scene_tree *tree;
+	struct wlr_scene_rect *bg;
+	struct switcher_tile *tiles;
+	int count;
+	int index;
+	int tile_h;
+} sw;
+
+static bool switcher_is_active(void) { return sw.tree != NULL; }
+
+static bool switcher_candidate(Client *c) {
+	if (!c->mon || c->iskilling || c->isminimized || c->isunglobal ||
+		c->is_logic_hide || !client_surface(c) || !client_surface(c)->mapped ||
+		client_is_unmanaged(c) || client_is_x11_popup(c))
+		return false;
+	return (int32_t)c->tags > 0;
+}
+
+static void switcher_content_size(Client *c, float *w, float *h) {
+#ifdef XWAYLAND
+	if (client_is_x11(c)) {
+		struct wlr_surface *s = client_surface(c);
+		*w = s->current.width;
+		*h = s->current.height;
+		return;
+	}
+#endif
+	*w = c->surface.xdg->geometry.width;
+	*h = c->surface.xdg->geometry.height;
+}
+
+// map the surface tree into the fixed tile box, re-run after each commit
+// because the content size or clip may change
+static void switcher_tile_layout(struct switcher_tile *tile) {
+	struct wlr_box clip;
+	float src_w, src_h;
+	client_get_clip(tile->c, &clip);
+	switcher_content_size(tile->c, &src_w, &src_h);
+	if (src_w <= 0 || src_h <= 0)
+		return;
+
+	float scale_x = (float)tile->cw / src_w;
+	float scale_y = (float)sw.tile_h / src_h;
+	struct switcher_surface *entry;
+	wl_list_for_each(entry, &tile->surfaces, link) {
+		struct wlr_surface *s = entry->surface;
+		if (entry->is_root) {
+			float ratio_x =
+				s->current.width > 0
+					? (float)s->current.buffer_width / s->current.width
+					: 1.0f;
+			float ratio_y =
+				s->current.height > 0
+					? (float)s->current.buffer_height / s->current.height
+					: 1.0f;
+			struct wlr_fbox src = {
+				.x = clip.x * ratio_x,
+				.y = clip.y * ratio_y,
+				.width = src_w * ratio_x,
+				.height = src_h * ratio_y,
+			};
+			wlr_scene_buffer_set_source_box(entry->buffer, &src);
+			wlr_scene_node_set_position(&entry->buffer->node, 0, 0);
+			wlr_scene_buffer_set_dest_size(entry->buffer, tile->cw, sw.tile_h);
+		} else {
+			wlr_scene_node_set_position(&entry->buffer->node,
+										(int)((entry->sx - clip.x) * scale_x),
+										(int)((entry->sy - clip.y) * scale_y));
+			wlr_scene_buffer_set_dest_size(entry->buffer,
+										   (int)(s->current.width * scale_x),
+										   (int)(s->current.height * scale_y));
+		}
+	}
+}
+
+static void switcher_surface_finish(struct switcher_surface *entry) {
+	wl_list_remove(&entry->commit.link);
+	wl_list_remove(&entry->destroy.link);
+	wl_list_remove(&entry->output_sample.link);
+	wl_list_remove(&entry->frame_done.link);
+	wl_list_remove(&entry->link);
+	free(entry);
+}
+
+static void switcher_surface_update_buffer(struct switcher_surface *entry) {
+	struct wlr_surface *surface = entry->surface;
+	struct wlr_scene_buffer *buffer = entry->buffer;
+
+	struct wlr_fbox source;
+	wlr_surface_get_buffer_source_box(surface, &source);
+	wlr_scene_buffer_set_source_box(buffer, &source);
+	wlr_scene_buffer_set_transform(buffer, surface->current.transform);
+
+	const struct wlr_alpha_modifier_surface_v1_state *alpha =
+		wlr_alpha_modifier_v1_get_surface_state(surface);
+	wlr_scene_buffer_set_opacity(buffer,
+								 alpha ? (float)alpha->multiplier : 1.0f);
+
+	enum wlr_color_transfer_function transfer_function =
+		WLR_COLOR_TRANSFER_FUNCTION_GAMMA22;
+	enum wlr_color_named_primaries primaries = WLR_COLOR_NAMED_PRIMARIES_SRGB;
+	const struct wlr_image_description_v1_data *image =
+		wlr_surface_get_image_description_v1_data(surface);
+	if (image) {
+		transfer_function =
+			wlr_color_manager_v1_transfer_function_to_wlr(image->tf_named);
+		primaries =
+			wlr_color_manager_v1_primaries_to_wlr(image->primaries_named);
+	}
+	wlr_scene_buffer_set_transfer_function(buffer, transfer_function);
+	wlr_scene_buffer_set_primaries(buffer, primaries);
+
+	enum wlr_color_encoding encoding = WLR_COLOR_ENCODING_NONE;
+	enum wlr_color_range range = WLR_COLOR_RANGE_NONE;
+	const struct wlr_color_representation_v1_surface_state *representation =
+		wlr_color_representation_v1_get_surface_state(surface);
+	if (representation) {
+		if (representation->coefficients)
+			encoding = wlr_color_representation_v1_color_encoding_to_wlr(
+				representation->coefficients);
+		if (representation->range)
+			range = wlr_color_representation_v1_color_range_to_wlr(
+				representation->range);
+	}
+	wlr_scene_buffer_set_color_encoding(buffer, encoding);
+	wlr_scene_buffer_set_color_range(buffer, range);
+
+	if (!surface->buffer || surface->current.width <= 0 ||
+		surface->current.height <= 0) {
+		wlr_scene_buffer_set_buffer(buffer, NULL);
+		return;
+	}
+
+	struct wlr_scene_buffer_set_buffer_options options = {
+		.damage = &surface->buffer_damage,
+	};
+	struct wlr_linux_drm_syncobj_surface_v1_state *syncobj =
+		wlr_linux_drm_syncobj_v1_get_surface_state(surface);
+	if (syncobj) {
+		options.wait_timeline = syncobj->acquire_timeline;
+		options.wait_point = syncobj->acquire_point;
+	}
+	wlr_scene_buffer_set_buffer_with_options(buffer, &surface->buffer->base,
+											 &options);
+}
+
+static void switcher_surface_commit(struct wl_listener *listener, void *data) {
+	struct switcher_surface *entry = wl_container_of(listener, entry, commit);
+	switcher_surface_update_buffer(entry);
+	switcher_tile_layout(entry->tile);
+}
+
+static void switcher_surface_destroy(struct wl_listener *listener, void *data) {
+	struct switcher_surface *entry = wl_container_of(listener, entry, destroy);
+	struct wlr_scene_buffer *buffer = entry->buffer;
+	switcher_surface_finish(entry);
+	wlr_scene_node_destroy(&buffer->node);
+}
+
+static void switcher_surface_output_sample(struct wl_listener *listener,
+										   void *data) {
+	struct switcher_surface *entry =
+		wl_container_of(listener, entry, output_sample);
+	const struct wlr_scene_output_sample_event *event = data;
+	if (entry->buffer->primary_output != event->output)
+		return;
+
+	struct wlr_output *output = event->output->output;
+	if (event->direct_scanout)
+		wlr_presentation_surface_scanned_out_on_output(entry->surface, output);
+	else
+		wlr_presentation_surface_textured_on_output(entry->surface, output);
+
+	struct wlr_linux_drm_syncobj_surface_v1_state *syncobj =
+		wlr_linux_drm_syncobj_v1_get_surface_state(entry->surface);
+	if (syncobj && event->release_timeline)
+		wlr_linux_drm_syncobj_v1_state_add_release_point(
+			syncobj, event->release_timeline, event->release_point,
+			output->event_loop);
+}
+
+// hidden clients are paced by the preview buffer
+static void switcher_surface_frame_done(struct wl_listener *listener,
+										void *data) {
+	struct switcher_surface *entry =
+		wl_container_of(listener, entry, frame_done);
+	struct wlr_scene_frame_done_event *event = data;
+	if (entry->buffer->primary_output == event->output)
+		wlr_surface_send_frame_done(entry->surface, &event->when);
+}
+
+static void switcher_tile_add_surface(struct wlr_surface *surface, int sx,
+									  int sy, void *data) {
+	struct switcher_tile *tile = data;
+
+	// only the real scene surface may update wl_surface output membership
+	struct wlr_scene_buffer *buffer =
+		wlr_scene_buffer_create(tile->content, NULL);
+	if (!buffer)
+		return;
+
+	struct switcher_surface *entry = ecalloc(1, sizeof(*entry));
+	entry->tile = tile;
+	entry->surface = surface;
+	entry->buffer = buffer;
+	entry->sx = sx;
+	entry->sy = sy;
+	entry->is_root = surface == client_surface(tile->c);
+	wlr_scene_buffer_set_filter_mode(entry->buffer, WLR_SCALE_FILTER_BILINEAR);
+	switcher_surface_update_buffer(entry);
+
+	LISTEN(&surface->events.commit, &entry->commit, switcher_surface_commit);
+	LISTEN(&surface->events.destroy, &entry->destroy, switcher_surface_destroy);
+	LISTEN(&buffer->events.output_sample, &entry->output_sample,
+		   switcher_surface_output_sample);
+	LISTEN(&buffer->events.frame_done, &entry->frame_done,
+		   switcher_surface_frame_done);
+	wl_list_insert(&tile->surfaces, &entry->link);
+}
+
+static void switcher_tile_create(struct switcher_tile *tile, Client *c) {
+	tile->c = c;
+	wl_list_init(&tile->surfaces);
+	float src_w, src_h;
+	switcher_content_size(c, &src_w, &src_h);
+	float aspect = src_w > 0 && src_h > 0 ? src_w / src_h : 1.0f;
+	aspect = MANGO_MAX(SW_ASPECT_MIN, MANGO_MIN(aspect, SW_ASPECT_MAX));
+	tile->cw = MANGO_MAX(1, (int)(sw.tile_h * aspect));
+
+	tile->tree = wlr_scene_tree_create(sw.tree);
+	tile->frame = wlr_scene_rect_create(tile->tree, 1, 1, config.bordercolor);
+	tile->content = wlr_scene_tree_create(tile->tree);
+	wlr_scene_node_set_position(&tile->content->node, SW_PAD, SW_PAD);
+	wlr_surface_for_each_surface(client_surface(c), switcher_tile_add_surface,
+								 tile);
+	switcher_tile_layout(tile);
+}
+
+static void switcher_layout(void) {
+	int frame_h = sw.tile_h + 2 * SW_PAD;
+	int maxrow_w =
+		MANGO_MAX(1, (int)(sw.mon->m.width * SW_PANEL_FRAC) - 2 * SW_MARGIN);
+
+	int nrows = 1;
+	int row_w = 0;
+	int content_w = 0;
+	for (int i = 0; i < sw.count; i++) {
+		struct switcher_tile *tile = &sw.tiles[i];
+		int fw = tile->cw + 2 * SW_PAD;
+		if (row_w > 0 && row_w + SW_GAP + fw > maxrow_w) {
+			nrows++;
+			row_w = fw;
+		} else {
+			row_w = row_w == 0 ? fw : row_w + SW_GAP + fw;
+		}
+		tile->row = nrows - 1;
+		content_w = MANGO_MAX(content_w, row_w);
+	}
+
+	int *rowsw = ecalloc(nrows, sizeof(*rowsw));
+	for (int i = 0; i < sw.count; i++) {
+		struct switcher_tile *tile = &sw.tiles[i];
+		int fw = tile->cw + 2 * SW_PAD;
+		rowsw[tile->row] += rowsw[tile->row] == 0 ? fw : SW_GAP + fw;
+	}
+
+	int panel_w = content_w + 2 * SW_MARGIN;
+	int panel_h = 2 * SW_MARGIN + nrows * frame_h + (nrows - 1) * SW_GAP;
+	wlr_scene_node_set_position(&sw.tree->node,
+								sw.mon->m.x + (sw.mon->m.width - panel_w) / 2,
+								sw.mon->m.y + (sw.mon->m.height - panel_h) / 2);
+	wlr_scene_rect_set_size(sw.bg, panel_w, panel_h);
+
+	int row = -1;
+	int x = 0;
+	for (int i = 0; i < sw.count; i++) {
+		struct switcher_tile *tile = &sw.tiles[i];
+		if (tile->row != row) {
+			row = tile->row;
+			x = SW_MARGIN + (content_w - rowsw[row]) / 2;
+		}
+		wlr_scene_node_set_position(&tile->tree->node, x,
+									SW_MARGIN + row * (frame_h + SW_GAP));
+		wlr_scene_rect_set_size(tile->frame, tile->cw + 2 * SW_PAD, frame_h);
+		x += tile->cw + 2 * SW_PAD + SW_GAP;
+	}
+	free(rowsw);
+}
+
+static void switcher_apply_highlight(void) {
+	for (int i = 0; i < sw.count; i++)
+		wlr_scene_rect_set_color(sw.tiles[i].frame, i == sw.index
+														? config.focuscolor
+														: config.bordercolor);
+}
+
+static void switcher_close(void) {
+	if (!switcher_is_active())
+		return;
+	for (int i = 0; i < sw.count; i++) {
+		struct switcher_surface *entry, *tmp;
+		wl_list_for_each_safe(entry, tmp, &sw.tiles[i].surfaces, link) {
+			switcher_surface_finish(entry);
+		}
+	}
+	wlr_scene_node_destroy(&sw.tree->node);
+	free(sw.tiles);
+	memset(&sw, 0, sizeof(sw));
+}
+
+static void switcher_commit_client(Client *tc) {
+	switcher_close();
+	if (!switcher_candidate(tc))
+		return;
+	if (!VISIBLEON(tc, tc->mon))
+		view_in_mon(&(Arg){.ui = get_tags_first_tag(tc->tags)}, true, tc->mon,
+					true);
+	focusclient(tc, 1);
+}
+
+static void switcher_commit(void) {
+	if (!switcher_is_active())
+		return;
+	switcher_commit_client(sw.tiles[sw.index].c);
+}
+
+static Client *switcher_client_at(double lx, double ly) {
+	if (!switcher_is_active())
+		return NULL;
+	for (int i = 0; i < sw.count; i++) {
+		struct switcher_tile *tile = &sw.tiles[i];
+		struct wlr_box box = {
+			.width = tile->cw + 2 * SW_PAD,
+			.height = sw.tile_h + 2 * SW_PAD,
+		};
+		if (!wlr_scene_node_coords(&tile->tree->node, &box.x, &box.y) ||
+			!wlr_box_contains_point(&box, lx, ly))
+			continue;
+		return tile->c;
+	}
+	return NULL;
+}
+
+static void switcher_open(int dir) {
+	Client *c;
+	Monitor *m;
+	int n = 0;
+
+	wl_list_for_each(m, &mons, link) {
+		if (m->isoverview)
+			return;
+	}
+	wl_list_for_each(c, &fstack, flink) {
+		if (switcher_candidate(c))
+			n++;
+	}
+	if (n == 0)
+		return;
+
+	sw.mon = selmon;
+	int max_row_w = (int)(sw.mon->m.width * SW_PANEL_FRAC) - 2 * SW_MARGIN;
+	int max_panel_h = (int)(sw.mon->m.height * SW_PANEL_FRAC);
+	// size against the widest allowed tile so the panel always fits
+	sw.tile_h = 1;
+	for (int cols = 1; cols <= n; cols++) {
+		int rows = (n + cols - 1) / cols;
+		int h_by_w =
+			(int)((max_row_w - (cols - 1) * SW_GAP - 2 * cols * SW_PAD) /
+				  (cols * SW_ASPECT_MAX));
+		int h_by_h =
+			(max_panel_h - 2 * SW_MARGIN - (rows - 1) * SW_GAP) / rows -
+			2 * SW_PAD;
+		int h = MANGO_MIN((int)(sw.mon->m.height * SW_TILE_FRAC),
+						  MANGO_MIN(h_by_w, h_by_h));
+		sw.tile_h = MANGO_MAX(sw.tile_h, h);
+	}
+
+	sw.tree = wlr_scene_tree_create(layers[LyrOverlay]);
+	sw.bg = wlr_scene_rect_create(sw.tree, 1, 1, switcher_panel_color);
+	sw.tiles = ecalloc(n, sizeof(*sw.tiles));
+	int current_index = -1;
+	wl_list_for_each(c, &fstack, flink) {
+		if (!switcher_candidate(c))
+			continue;
+		if (c == selmon->sel)
+			current_index = sw.count;
+		switcher_tile_create(&sw.tiles[sw.count++], c);
+	}
+	sw.index = current_index >= 0 ? (current_index + dir + sw.count) % sw.count
+								  : (dir > 0 ? 0 : sw.count - 1);
+	switcher_layout();
+	switcher_apply_highlight();
+
+	// restart render loops of clients idling without frame callbacks so
+	// tiles of hidden windows stay live, like overview cards
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	for (int i = 0; i < sw.count; i++)
+		client_send_frame_done(sw.tiles[i].c, &now);
+}
+
+static void switcher_cycle(int dir) {
+	sw.index = (sw.index + dir + sw.count) % sw.count;
+	switcher_apply_highlight();
+}
+
+void switcher(const Arg *arg) {
+	int dir = arg && arg->i == PREV ? -1 : 1;
+	if (locked || !selmon || selmon->is_jump_mode)
+		return;
+	if (switcher_is_active())
+		switcher_cycle(dir);
+	else
+		switcher_open(dir);
+}

--- a/src/switcher/switcher.h
+++ b/src/switcher/switcher.h
@@ -35,7 +35,7 @@ static struct {
 	Monitor *mon;
 	struct wlr_scene_tree *tree;
 	struct wlr_scene_rect *bg;
-	struct switcher_tile *tiles;
+	struct switcher_tile **tiles;
 	int count;
 	int index;
 	int tile_h;
@@ -280,7 +280,7 @@ static void switcher_layout(void) {
 	int row_w = 0;
 	int content_w = 0;
 	for (int i = 0; i < sw.count; i++) {
-		struct switcher_tile *tile = &sw.tiles[i];
+		struct switcher_tile *tile = sw.tiles[i];
 		int fw = tile->cw + 2 * SW_PAD;
 		if (row_w > 0 && row_w + SW_GAP + fw > maxrow_w) {
 			nrows++;
@@ -294,7 +294,7 @@ static void switcher_layout(void) {
 
 	int *rowsw = ecalloc(nrows, sizeof(*rowsw));
 	for (int i = 0; i < sw.count; i++) {
-		struct switcher_tile *tile = &sw.tiles[i];
+		struct switcher_tile *tile = sw.tiles[i];
 		int fw = tile->cw + 2 * SW_PAD;
 		rowsw[tile->row] += rowsw[tile->row] == 0 ? fw : SW_GAP + fw;
 	}
@@ -309,7 +309,7 @@ static void switcher_layout(void) {
 	int row = -1;
 	int x = 0;
 	for (int i = 0; i < sw.count; i++) {
-		struct switcher_tile *tile = &sw.tiles[i];
+		struct switcher_tile *tile = sw.tiles[i];
 		if (tile->row != row) {
 			row = tile->row;
 			x = SW_MARGIN + (content_w - rowsw[row]) / 2;
@@ -324,9 +324,9 @@ static void switcher_layout(void) {
 
 static void switcher_apply_highlight(void) {
 	for (int i = 0; i < sw.count; i++)
-		wlr_scene_rect_set_color(sw.tiles[i].frame, i == sw.index
-														? config.focuscolor
-														: config.bordercolor);
+		wlr_scene_rect_set_color(sw.tiles[i]->frame, i == sw.index
+														 ? config.focuscolor
+														 : config.bordercolor);
 }
 
 static void switcher_close(void) {
@@ -334,13 +334,49 @@ static void switcher_close(void) {
 		return;
 	for (int i = 0; i < sw.count; i++) {
 		struct switcher_surface *entry, *tmp;
-		wl_list_for_each_safe(entry, tmp, &sw.tiles[i].surfaces, link) {
+		wl_list_for_each_safe(entry, tmp, &sw.tiles[i]->surfaces, link) {
 			switcher_surface_finish(entry);
 		}
 	}
 	wlr_scene_node_destroy(&sw.tree->node);
+	for (int i = 0; i < sw.count; i++)
+		free(sw.tiles[i]);
 	free(sw.tiles);
 	memset(&sw, 0, sizeof(sw));
+}
+
+// remove a single tile while the switcher stays open, then relayout
+static void switcher_remove_client(Client *c) {
+	if (!switcher_is_active())
+		return;
+	int i;
+	for (i = 0; i < sw.count; i++) {
+		if (sw.tiles[i]->c == c)
+			break;
+	}
+	if (i == sw.count)
+		return;
+
+	struct switcher_surface *entry, *tmp;
+	wl_list_for_each_safe(entry, tmp, &sw.tiles[i]->surfaces, link) {
+		switcher_surface_finish(entry);
+	}
+	wlr_scene_node_destroy(&sw.tiles[i]->tree->node);
+	free(sw.tiles[i]);
+
+	if (sw.index > i)
+		sw.index--;
+	memmove(&sw.tiles[i], &sw.tiles[i + 1],
+			(sw.count - i - 1) * sizeof(*sw.tiles));
+	sw.count--;
+	if (sw.count == 0) {
+		switcher_close();
+		return;
+	}
+	if (sw.index >= sw.count)
+		sw.index = sw.count - 1;
+	switcher_layout();
+	switcher_apply_highlight();
 }
 
 static void switcher_commit_client(Client *tc) {
@@ -356,14 +392,14 @@ static void switcher_commit_client(Client *tc) {
 static void switcher_commit(void) {
 	if (!switcher_is_active())
 		return;
-	switcher_commit_client(sw.tiles[sw.index].c);
+	switcher_commit_client(sw.tiles[sw.index]->c);
 }
 
 static Client *switcher_client_at(double lx, double ly) {
 	if (!switcher_is_active())
 		return NULL;
 	for (int i = 0; i < sw.count; i++) {
-		struct switcher_tile *tile = &sw.tiles[i];
+		struct switcher_tile *tile = sw.tiles[i];
 		struct wlr_box box = {
 			.width = tile->cw + 2 * SW_PAD,
 			.height = sw.tile_h + 2 * SW_PAD,
@@ -419,7 +455,9 @@ static void switcher_open(int dir) {
 			continue;
 		if (c == selmon->sel)
 			current_index = sw.count;
-		switcher_tile_create(&sw.tiles[sw.count++], c);
+		struct switcher_tile *tile = ecalloc(1, sizeof(*tile));
+		switcher_tile_create(tile, c);
+		sw.tiles[sw.count++] = tile;
 	}
 	sw.index = current_index >= 0 ? (current_index + dir + sw.count) % sw.count
 								  : (dir > 0 ? 0 : sw.count - 1);
@@ -431,7 +469,7 @@ static void switcher_open(int dir) {
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 	for (int i = 0; i < sw.count; i++)
-		client_send_frame_done(sw.tiles[i].c, &now);
+		client_send_frame_done(sw.tiles[i]->c, &now);
 }
 
 static void switcher_cycle(int dir) {

--- a/src/switcher/switcher.h
+++ b/src/switcher/switcher.h
@@ -412,7 +412,7 @@ static Client *switcher_client_at(double lx, double ly) {
 	return NULL;
 }
 
-static void switcher_open(int dir) {
+static void switcher_open(void) {
 	Client *c;
 	Monitor *m;
 	int n = 0;
@@ -449,18 +449,16 @@ static void switcher_open(int dir) {
 	sw.tree = wlr_scene_tree_create(layers[LyrOverlay]);
 	sw.bg = wlr_scene_rect_create(sw.tree, 1, 1, switcher_panel_color);
 	sw.tiles = ecalloc(n, sizeof(*sw.tiles));
-	int current_index = -1;
 	wl_list_for_each(c, &fstack, flink) {
 		if (!switcher_candidate(c))
 			continue;
-		if (c == selmon->sel)
-			current_index = sw.count;
 		struct switcher_tile *tile = ecalloc(1, sizeof(*tile));
 		switcher_tile_create(tile, c);
 		sw.tiles[sw.count++] = tile;
 	}
-	sw.index = current_index >= 0 ? (current_index + dir + sw.count) % sw.count
-								  : (dir > 0 ? 0 : sw.count - 1);
+	// 当前窗口位于 fstack 头部（tiles[0]），选中第二个并提交后会被插到
+	// 最前，下次打开时原来的第一个变成第二个，从而在最近两个窗口间往返
+	sw.index = sw.count > 1 ? 1 : 0;
 	switcher_layout();
 	switcher_apply_highlight();
 
@@ -484,5 +482,5 @@ void switcher(const Arg *arg) {
 	if (switcher_is_active())
 		switcher_cycle(dir);
 	else
-		switcher_open(dir);
+		switcher_open();
 }


### PR DESCRIPTION
#450 
Adds animations that play when a window is minimized, restored from being minimized, or the scratchpad is toggled. Uses the same animation types as open and close, (i.e. slide, zoom, fade, none). 

Defined in config.conf: 
```
animation_type_unminimize=zoom (default)
animation_type_minimize=fade (default)

animation_duration_unminimize=350 (default)
animation_duration_minimize=300 (default)

animation_curve_unminimize=0.46,1.0,0.29,0.99 (default)
animation_curve_minimize=0.46,1.0,0.29,0.99 (default
```

Animation types can also be applied for window rules, and work with the `isnoanimation` flag, (which, side-note, is pretty buggy right now)