### PR TITLE
(nix) added clang-tools to nix flake devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
             scenefx = inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}.default;
           };
           shellOverride = old: {
-            nativeBuildInputs = old.nativeBuildInputs ++ [ ];
+            nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.clang-tools ];
             buildInputs = old.buildInputs ++ [ ];
           };
         in


### PR DESCRIPTION
This change allows format.sh to be run from the devshell (nix develop) without needing clang-tools installed globally on the system.

