### PR TITLE
fix: Ignore no_radius_when_single for floating windows

### DIFF
--- a/src/animation/client.h
+++ b/src/animation/client.h
@@ -266,8 +266,10 @@ void buffer_set_effect(Client *c, BufferData data) {
 	if (c == grabc)
 		data.should_scale = false;
 
-	if (c->isfullscreen || (config.no_radius_when_single && c->mon &&
-							c->mon->visible_tiling_clients == 1))
+	if (c->isfullscreen ||
+		(config.no_radius_when_single && c->mon &&
+		 (c->ismaximizescreen ||
+		  (ISSCROLLTILED(c) && c->mon->visible_fake_tiling_clients == 1))))
 		data.corner_location = corner_radii_none();
 
 	if (config.blur && !c->noblur)
@@ -300,7 +302,9 @@ void client_draw_shadow(Client *c, struct ivec2 offsets) {
 	bool hit_no_border = check_hit_no_border(c);
 	struct fx_corner_radii current_corner_location =
 		c->isfullscreen || (config.no_radius_when_single && c->mon &&
-							c->mon->visible_tiling_clients == 1)
+							(c->ismaximizescreen ||
+							 (ISSCROLLTILED(c) &&
+							  c->mon->visible_fake_tiling_clients == 1)))
 			? corner_radii_none()
 			: set_client_corner_location(c);
 
@@ -627,7 +631,9 @@ void client_draw_border(Client *c, struct ivec2 offsets) {
 
 	struct fx_corner_radii current_corner_location =
 		c->isfullscreen || (config.no_radius_when_single && c->mon &&
-							c->mon->visible_tiling_clients == 1)
+							(c->ismaximizescreen ||
+							 (ISSCROLLTILED(c) &&
+							  c->mon->visible_fake_tiling_clients == 1)))
 			? corner_radii_none()
 			: set_client_corner_location(c);
 


### PR DESCRIPTION
Fixes floating windows above a single tiled / maximized window having no radius with the no_radius_when_single option, when it should just be the tiled / maximized window with no radius.