### PR TITLE
fix: match candidates based on edges instead of centers in find_client_by_direction

### DIFF
--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -842,8 +842,9 @@ Client *center_tiled_select(Monitor *m) {
 Client *find_client_by_direction(Client *tc, const Arg *arg,
 								 bool findfloating) {
 	Client *c = NULL;
-	Client *tempFocusClients = NULL;
-	Client *tempSameMonitorFocusClients = NULL;
+	Client *found = NULL;
+	Client *found_same_monitor = NULL;
+
 	int64_t distance = LLONG_MAX;
 	int64_t same_monitor_distance = LLONG_MAX;
 
@@ -851,11 +852,9 @@ Client *find_client_by_direction(Client *tc, const Arg *arg,
 	int32_t tc_r = tc->geom.x + tc->geom.width;
 	int32_t tc_t = tc->geom.y;
 	int32_t tc_b = tc->geom.y + tc->geom.height;
-	int32_t tc_cx = tc_l + tc->geom.width / 2;
-	int32_t tc_cy = tc_t + tc->geom.height / 2;
 
 	for (int32_t step = 0; step < 2; step++) {
-		if (step == 1 && tempFocusClients)
+		if (step == 1 && found)
 			break;
 
 		wl_list_for_each(c, &clients, link) {
@@ -876,55 +875,57 @@ Client *find_client_by_direction(Client *tc, const Arg *arg,
 			int32_t c_r = c->geom.x + c->geom.width;
 			int32_t c_t = c->geom.y;
 			int32_t c_b = c->geom.y + c->geom.height;
-			int32_t c_cx = c_l + c->geom.width / 2;
-			int32_t c_cy = c_t + c->geom.height / 2;
 
 			int64_t main_dist = 0;
 			int64_t orth_dist = 0;
-			bool match_dir = false;
+			bool matched = false;
 
 			switch (arg->i) {
-			case LEFT:
-				if (c_cx < tc_cx || (c_cx == tc_cx && c_l < tc_l)) {
-					match_dir = true;
-					main_dist = tc_l - c_r;
-					orth_dist = (c_b < tc_t)
-									? (tc_t - c_b)
-									: ((c_t > tc_b) ? (c_t - tc_b) : 0);
-				}
-				break;
-			case RIGHT:
-				if (c_cx > tc_cx || (c_cx == tc_cx && c_l > tc_l)) {
-					match_dir = true;
-					main_dist = c_l - tc_r;
-					orth_dist = (c_b < tc_t)
-									? (tc_t - c_b)
-									: ((c_t > tc_b) ? (c_t - tc_b) : 0);
-				}
-				break;
 			case UP:
-				if (c_cy < tc_cy || (c_cy == tc_cy && c_t < tc_t)) {
-					match_dir = true;
+				if (c_b <= tc_t) {
+					matched = true;
 					main_dist = tc_t - c_b;
 					orth_dist = (c_r < tc_l)
 									? (tc_l - c_r)
 									: ((c_l > tc_r) ? (c_l - tc_r) : 0);
 				}
 				break;
+
 			case DOWN:
-				if (c_cy > tc_cy || (c_cy == tc_cy && c_t > tc_t)) {
-					match_dir = true;
+				if (c_t >= tc_b) {
+					matched = true;
 					main_dist = c_t - tc_b;
 					orth_dist = (c_r < tc_l)
 									? (tc_l - c_r)
 									: ((c_l > tc_r) ? (c_l - tc_r) : 0);
 				}
 				break;
+
+			case RIGHT:
+				if (c_l >= tc_r) {
+					matched = true;
+					main_dist = c_l - tc_r;
+					orth_dist = (c_b < tc_t)
+									? (tc_t - c_b)
+									: ((c_t > tc_b) ? (c_t - tc_b) : 0);
+				}
+				break;
+
+			case LEFT:
+				if (c_r <= tc_l) {
+					matched = true;
+					main_dist = tc_l - c_r;
+					orth_dist = (c_b < tc_t)
+									? (tc_t - c_b)
+									: ((c_t > tc_b) ? (c_t - tc_b) : 0);
+				}
+				break;
+
 			default:
 				continue;
 			}
 
-			if (!match_dir)
+			if (!matched)
 				continue;
 
 			if (step == 0) {
@@ -937,35 +938,27 @@ Client *find_client_by_direction(Client *tc, const Arg *arg,
 					continue;
 			}
 
-			int64_t penalty = 0;
-			if (main_dist < 0) {
-				penalty = 10000000000LL;
-				main_dist = -main_dist;
-			}
+			int64_t no_overlap_penalty = orth_dist > 0 ? 10000000LL : 0;
 
-			int64_t no_overlap_penalty = 0;
-			if (orth_dist > 0) {
-				no_overlap_penalty = 10000000LL;
-			}
-
-			int64_t tmp_distance = penalty + no_overlap_penalty +
+			int64_t tmp_distance = no_overlap_penalty +
 								   (main_dist * main_dist) +
 								   (orth_dist * orth_dist);
 
 			if (tmp_distance < distance) {
 				distance = tmp_distance;
-				tempFocusClients = c;
+				found = c;
 			}
+
 			if (c->mon == tc->mon && tmp_distance < same_monitor_distance) {
 				same_monitor_distance = tmp_distance;
-				tempSameMonitorFocusClients = c;
+				found_same_monitor = c;
 			}
 		}
 	}
 
-	if (tempSameMonitorFocusClients)
-		return tempSameMonitorFocusClients;
-	return tempFocusClients;
+	if (found_same_monitor)
+		return found_same_monitor;
+	return found;
 }
 
 Client *direction_select(const Arg *arg) {


### PR DESCRIPTION
fix #1338