### PR TITLE
fix: restore seat keyboard after active keyboard destruction

### DIFF
--- a/src/input/keyboard.h
+++ b/src/input/keyboard.h
@@ -221,13 +221,17 @@ static void create_standalone_keyboard(InputDevice *input_dev,
 	input_dev->device_data = group;
 }
 
+static void restore_default_seat_keyboard(void *data) {
+	if (seat && kb_group && !wlr_seat_get_keyboard(seat))
+		wlr_seat_set_keyboard(seat, kb_group->keyboard);
+}
+
 void destroy_standalone_keyboard(struct wl_listener *listener, void *data) {
 	KeyboardGroup *group = wl_container_of(listener, group, destroy);
 	if (group->keyboard == last_active_keyboard)
 		last_active_keyboard = NULL;
-	// devicerule 的键盘不在 kb_group 里，拔掉时要是正占着 seat 就悬空，
-	// 反正下一次按键会重新设置
-	if (wlr_seat_get_keyboard(seat) == group->keyboard)
+	bool restore_keyboard = wlr_seat_get_keyboard(seat) == group->keyboard;
+	if (restore_keyboard)
 		wlr_seat_set_keyboard(seat, NULL);
 	wl_list_remove(&group->key.link);
 	wl_list_remove(&group->modifiers.link);
@@ -238,6 +242,8 @@ void destroy_standalone_keyboard(struct wl_listener *listener, void *data) {
 	}
 	wl_list_remove(&group->link);
 	free(group);
+	if (restore_keyboard)
+		wl_event_loop_add_idle(event_loop, restore_default_seat_keyboard, NULL);
 }
 
 KeyboardGroup *createkeyboardgroup(void) {
@@ -313,8 +319,8 @@ void destroykeyboardgroup(struct wl_listener *listener, void *data) {
 	KeyboardGroup *group = wl_container_of(listener, group, destroy);
 	if (group->keyboard == last_active_keyboard)
 		last_active_keyboard = NULL;
-	// 销毁的是整个组，组的键盘也跟着没了。它要是正占着 seat 就悬空，
-	// 后面按键会重新设置
+	bool restore_keyboard = group->virtual_keyboard &&
+							wlr_seat_get_keyboard(seat) == group->keyboard;
 	if (wlr_seat_get_keyboard(seat) == group->keyboard)
 		wlr_seat_set_keyboard(seat, NULL);
 	wl_event_source_remove(group->key_repeat_source);
@@ -323,6 +329,8 @@ void destroykeyboardgroup(struct wl_listener *listener, void *data) {
 	wl_list_remove(&group->destroy.link);
 	wlr_keyboard_group_destroy(group->wlr_group);
 	free(group);
+	if (restore_keyboard)
+		wl_event_loop_add_idle(event_loop, restore_default_seat_keyboard, NULL);
 }
 
 int32_t keyrepeat(void *data) {

--- a/src/input/keyboard.h
+++ b/src/input/keyboard.h
@@ -27,19 +27,26 @@ void createkeyboard(struct wlr_keyboard *keyboard) {
 
 	ConfigDeviceRule *rule = find_device_rule(&keyboard->base);
 	if (rule && device_rule_has_keyboard_settings(rule) && input_dev) {
-		/* 命中带键盘参数的 devicerule：独立创建，使用独立 keymap */
+		// 命中带键盘参数的 devicerule：独立创建，使用独立 keymap
 		input_dev->standalone = true;
 		create_standalone_keyboard(input_dev, keyboard, rule);
+		// seat 空着的话就让新键盘接管
+		if (!wlr_seat_get_keyboard(seat))
+			wlr_seat_set_keyboard(seat, keyboard);
 		return;
 	}
 
-	/* Set the keymap to match the group keymap */
+	// keymap 先跟组保持一致
 	wlr_keyboard_set_keymap(keyboard, kb_group->keyboard->keymap);
 
 	wlr_keyboard_notify_modifiers(keyboard, 0, 0, locked_mods, 0);
 
-	/* Add the new keyboard to the group */
+	// 把新键盘加进组里
 	wlr_keyboard_group_add_keyboard(kb_group->wlr_group, keyboard);
+
+	// seat 空着的话就让组键盘顶上
+	if (!wlr_seat_get_keyboard(seat))
+		wlr_seat_set_keyboard(seat, kb_group->keyboard);
 }
 
 /* 设备匹配：优先精确匹配 name / vendor:product:name 标识符，其次匹配类型 */
@@ -218,6 +225,10 @@ void destroy_standalone_keyboard(struct wl_listener *listener, void *data) {
 	KeyboardGroup *group = wl_container_of(listener, group, destroy);
 	if (group->keyboard == last_active_keyboard)
 		last_active_keyboard = NULL;
+	// devicerule 的键盘不在 kb_group 里，拔掉时要是正占着 seat 就悬空，
+	// 反正下一次按键会重新设置
+	if (wlr_seat_get_keyboard(seat) == group->keyboard)
+		wlr_seat_set_keyboard(seat, NULL);
 	wl_list_remove(&group->key.link);
 	wl_list_remove(&group->modifiers.link);
 	wl_list_remove(&group->destroy.link);
@@ -284,19 +295,17 @@ KeyboardGroup *createkeyboardgroup(void) {
 	wlr_keyboard_set_repeat_info(group->keyboard, config.repeat_rate,
 								 config.repeat_delay);
 
-	/* Set up listeners for keyboard events */
+	// 挂上按键和修饰键的监听
 	LISTEN(&group->keyboard->events.key, &group->key, keypress);
 	LISTEN(&group->keyboard->events.modifiers, &group->modifiers, keypressmod);
 
 	group->key_repeat_source =
 		wl_event_loop_add_timer(event_loop, keyrepeat, group);
 
-	/* A seat can only have one keyboard, but this is a limitation of the
-	 * Wayland protocol - not wlroots. We assign all connected keyboards to the
-	 * same wlr_keyboard_group, which provides a single wlr_keyboard interface
-	 * for all of them. Set this combined wlr_keyboard as the seat keyboard.
-	 */
-	wlr_seat_set_keyboard(seat, group->keyboard);
+	// seat 只能有一个键盘，物理键盘都合进这个组，对外只暴露组的键盘。
+	// seat 空着才设置，免得虚拟键盘一创建就把物理键盘顶掉
+	if (!wlr_seat_get_keyboard(seat))
+		wlr_seat_set_keyboard(seat, group->keyboard);
 	return group;
 }
 
@@ -304,6 +313,10 @@ void destroykeyboardgroup(struct wl_listener *listener, void *data) {
 	KeyboardGroup *group = wl_container_of(listener, group, destroy);
 	if (group->keyboard == last_active_keyboard)
 		last_active_keyboard = NULL;
+	// 销毁的是整个组，组的键盘也跟着没了。它要是正占着 seat 就悬空，
+	// 后面按键会重新设置
+	if (wlr_seat_get_keyboard(seat) == group->keyboard)
+		wlr_seat_set_keyboard(seat, NULL);
 	wl_event_source_remove(group->key_repeat_source);
 	wl_list_remove(&group->key.link);
 	wl_list_remove(&group->modifiers.link);
@@ -774,12 +787,12 @@ void handle_keyboard_shortcuts_inhibit_new_inhibitor(
 
 void virtualkeyboard(struct wl_listener *listener, void *data) {
 	struct wlr_virtual_keyboard_v1 *kb = data;
-	/* virtual keyboards shouldn't share keyboard group */
+	// 虚拟键盘不跟物理键盘合组
 	wlr_seat_set_capabilities(seat,
 							  seat->capabilities | WL_SEAT_CAPABILITY_KEYBOARD);
 	KeyboardGroup *group = createkeyboardgroup();
 	group->virtual_keyboard = &kb->keyboard;
-	/* 虚拟键盘也应用 devicerule 的独立 keymap/重复率 */
+	// 虚拟键盘也应用 devicerule 的独立 keymap/重复率
 	ConfigDeviceRule *rule = find_device_rule(&kb->keyboard.base);
 	if (rule && device_rule_has_keyboard_settings(rule)) {
 		struct xkb_keymap *keymap = compile_rule_keymap(rule);
@@ -794,12 +807,12 @@ void virtualkeyboard(struct wl_listener *listener, void *data) {
 										 : config.repeat_delay);
 		}
 	}
-	/* Set the keymap to match the group keymap */
+	// keymap 跟组保持一致
 	wlr_keyboard_set_keymap(&kb->keyboard, group->keyboard->keymap);
 	LISTEN(&kb->keyboard.base.events.destroy, &group->destroy,
 		   destroykeyboardgroup);
 
-	/* Add the new keyboard to the group */
+	// 把虚拟键盘加进组里
 	wlr_keyboard_group_add_keyboard(group->wlr_group, &kb->keyboard);
 }
 

--- a/src/input/keyboard.h
+++ b/src/input/keyboard.h
@@ -221,6 +221,9 @@ static void create_standalone_keyboard(InputDevice *input_dev,
 	input_dev->device_data = group;
 }
 
+/* Run after all keyboard destroy listeners. Restore the persistent group only
+ * if no other keyboard became active during destruction.
+ */
 static void restore_default_seat_keyboard(void *data) {
 	if (seat && kb_group && !wlr_seat_get_keyboard(seat))
 		wlr_seat_set_keyboard(seat, kb_group->keyboard);
@@ -230,6 +233,9 @@ void destroy_standalone_keyboard(struct wl_listener *listener, void *data) {
 	KeyboardGroup *group = wl_container_of(listener, group, destroy);
 	if (group->keyboard == last_active_keyboard)
 		last_active_keyboard = NULL;
+	/* A standalone keyboard is not part of kb_group. If it owns the seat when
+	 * removed, restore the persistent group after its destruction.
+	 */
 	bool restore_keyboard = wlr_seat_get_keyboard(seat) == group->keyboard;
 	if (restore_keyboard)
 		wlr_seat_set_keyboard(seat, NULL);
@@ -319,6 +325,9 @@ void destroykeyboardgroup(struct wl_listener *listener, void *data) {
 	KeyboardGroup *group = wl_container_of(listener, group, destroy);
 	if (group->keyboard == last_active_keyboard)
 		last_active_keyboard = NULL;
+	/* Destroying a non-active group must not change the seat. An active virtual
+	 * group needs the persistent group as a fallback after destruction.
+	 */
 	bool restore_keyboard = group->virtual_keyboard &&
 							wlr_seat_get_keyboard(seat) == group->keyboard;
 	if (wlr_seat_get_keyboard(seat) == group->keyboard)


### PR DESCRIPTION
## Summary

- Restore the persistent keyboard group (`kb_group`) after an active virtual-keyboard group is destroyed.
- Apply the same fallback when an active standalone keyboard is removed.
- Defer restoration to an idle callback; never overwrite another keyboard that became active during destruction.
- Identify virtual keyboard groups via `group->virtual_keyboard`, as requested in review.
- Keep the lifecycle rationale as comments rather than removing it.

Fixes #1344.

## Why

On current `main`, `createkeyboardgroup()` no longer replaces an existing seat keyboard, which fixed the virtual keyboard that is created and destroyed without sending input.

A virtual keyboard that sends a key or modifier still becomes the active seat keyboard through `keypress()` / `keypressmod()`. When that short-lived group is destroyed, `destroykeyboardgroup()` clears the seat keyboard but does not restore `kb_group->keyboard`. Mango keeps advertising `WL_SEAT_CAPABILITY_KEYBOARD`, so a client binding `wl_keyboard` afterwards receives no keymap and can later receive enter/modifier events without an XKB state (Electron crash / blank window).

The same lifecycle boundary exists for standalone keyboards created by keyboard-specific `devicerule` rules: they are not members of `kb_group`, may own the seat directly, and `destroy_standalone_keyboard()` also clears the seat without restoring the persistent group.

## What this change does

In both destroy handlers, record whether the keyboard being destroyed was the active seat keyboard:

- If it was active, clear the seat as before, then schedule an idle callback.
- The idle callback runs after all keyboard destroy listeners. It restores `kb_group->keyboard` only if the seat is still empty, so it never overwrites another keyboard activated during destruction.
- For the default `kb_group` itself (shutdown), no callback is scheduled, so the shutdown path is unchanged.

This is an immediate fallback policy for the confirmed bug. It does not attempt to choose between multiple still-live virtual keyboards; that can be investigated separately once the seat can no longer be left without a keymap.

## Testing

Tested against `main` at `a092a34aff906c6c53593b1ef8876fcd236fc1a1` with wlroots 0.20.2.

- `./format.sh`
- `git diff --check`
- regular Meson/Ninja build
- ASAN/UBSAN Meson/Ninja build
- headless `wl_keyboard.keymap` protocol reproducer (empty, key, and modifier virtual keyboards)

Current `main` before this change:

| scenario | result |
| --- | --- |
| empty virtual keyboard | `keymap=1` |
| virtual keyboard sends a key | `keymap=0` |

With this change:

| scenario | result |
| --- | --- |
| empty virtual keyboard | `keymap=1` (5/5) |
| virtual keyboard sends a key | `keymap=1` (5/5) |
| virtual keyboard sends a modifier | `keymap=1` |
| ASAN/UBSAN, empty and key | `keymap=1` |

The standalone keyboard path uses the same helper and is covered by the build and the fallback logic above; it is not exercised by the headless reproducer and has not been reproduced with a physical hot-unplug device.
