### PR TITLE
feature: monocle client count + dwm icons and bugfix: keybind delay on non-systemd distros

### DIFF
--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1117,6 +1117,11 @@ void spawn_shell(const Arg *arg) {
 	const char *activation_token = xdg_activation_v1_export_token();
 
 	if (fork() == 0) {
+		// fix: Explicitly unblock all signals inherited from wlroots
+		sigset_t set;
+		sigemptyset(&set);
+		sigprocmask(SIG_SETMASK, &set, NULL);
+
 		signal(SIGSEGV, SIG_DFL);
 		signal(SIGABRT, SIG_DFL);
 		signal(SIGILL, SIG_DFL);
@@ -1125,7 +1130,10 @@ void spawn_shell(const Arg *arg) {
 		if (activation_token)
 			setenv("XDG_ACTIVATION_TOKEN", activation_token, 1);
 
+		// close all file descriptors inherited from the parent process
 		int fd_max = sysconf(_SC_OPEN_MAX);
+		if (fd_max > 1024)
+			fd_max = 1024; // Prevent massive syscall delay
 		for (int i = 3; i < fd_max; i++) {
 			close(i);
 		}
@@ -1152,6 +1160,11 @@ void spawn(const Arg *arg) {
 	const char *activation_token = xdg_activation_v1_export_token();
 
 	if (fork() == 0) {
+		// fix: Explicitly unblock all signals inherited from wlroots
+		sigset_t set;
+		sigemptyset(&set);
+		sigprocmask(SIG_SETMASK, &set, NULL);
+
 		signal(SIGSEGV, SIG_DFL);
 		signal(SIGABRT, SIG_DFL);
 		signal(SIGILL, SIG_DFL);
@@ -1163,6 +1176,8 @@ void spawn(const Arg *arg) {
 		// close all file descriptors inherited from the parent process to
 		// prevent IPC handle leakage that can block clients
 		int fd_max = sysconf(_SC_OPEN_MAX);
+		if (fd_max > 1024)
+			fd_max = 1024; // Prevent massive syscall delay
 		for (int i = 3; i < fd_max; i++) {
 			close(i);
 		}

--- a/src/layout/horizontal.h
+++ b/src/layout/horizontal.h
@@ -584,10 +584,25 @@ void deck(Monitor *m) {
 	}
 }
 
+extern char monocle_symbol[16];
+
 void // 17
 monocle(Monitor *m) {
 	Client *c = NULL;
 	struct wlr_box geom;
+	int n = 0;
+
+	// count visible clients
+	wl_list_for_each(c, &clients, link) {
+		if (VISIBLEON(c, m) && ISFAKETILED(c))
+			n++;
+	}
+
+	// dynamically update the global monocle symbol buffer
+	if (n > 0)
+		snprintf(monocle_symbol, sizeof(monocle_symbol), "[%d]", n);
+	else
+		snprintf(monocle_symbol, sizeof(monocle_symbol), "[M]");
 
 	int32_t cur_gappov = enablegaps ? m->gappov : 0;
 	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -35,22 +35,24 @@ enum {
 	VERTICAL_FAIR,
 };
 
+char monocle_symbol[16] = "[M]";
+
 Layout layouts[] = {
 	// 最少两个,不能删除少于两个
 	/* symbol     arrange function   name */
-	{"T", tile, "tile", TILE},						 // 平铺布局
-	{"S", scroller, "scroller", SCROLLER},			 // 滚动布局
-	{"G", grid, "grid", GRID},						 // 格子布局
-	{"M", monocle, "monocle", MONOCLE},				 // 单屏布局
-	{"K", deck, "deck", DECK},						 // 卡片布局
-	{"CT", center_tile, "center_tile", CENTER_TILE}, // 居中布局
-	{"RT", right_tile, "right_tile", RIGHT_TILE},	 // 右布局
-	{"VS", vertical_scroller, "vertical_scroller",
-	 VERTICAL_SCROLLER},								   // 垂直滚动布局
-	{"VT", vertical_tile, "vertical_tile", VERTICAL_TILE}, // 垂直平铺布局
-	{"VG", vertical_grid, "vertical_grid", VERTICAL_GRID}, // 垂直格子布局
-	{"VK", vertical_deck, "vertical_deck", VERTICAL_DECK}, // 垂直卡片布局
-	{"DW", dwindle, "dwindle", DWINDLE},
+	{"::", tile, "tile", TILE},
+	{"==", scroller, "scroller", SCROLLER},
+	{"HHH", grid, "grid", GRID},
+	{monocle_symbol, monocle, "monocle",
+	 MONOCLE}, // <-- Use the variable here (no quotes)
+	{"H[]", deck, "deck", DECK},
+	{"|M|", center_tile, "center_tile", CENTER_TILE},
+	{"RT", right_tile, "right_tile", RIGHT_TILE},
+	{"VS", vertical_scroller, "vertical_scroller", VERTICAL_SCROLLER},
+	{"VT", vertical_tile, "vertical_tile", VERTICAL_TILE},
+	{"VG", vertical_grid, "vertical_grid", VERTICAL_GRID},
+	{"VK", vertical_deck, "vertical_deck", VERTICAL_DECK},
+	{"[\\]", dwindle, "dwindle", DWINDLE},
 	{"F", fair, "fair", FAIR},
 	{"VF", vertical_fair, "vertical_fair", VERTICAL_FAIR},
 };


### PR DESCRIPTION
### Summary
Two changes in this PR:
1. **Feature: Monocle Layout Enhancement:** Updates the monocle layout icon to display the active client count, just like how dwm does. Also, better icons for most layouts, as seen in dwm's [vanitygaps](https://dwm.suckless.org/patches/vanitygaps/) patch.  
2. **Fix: App Launch Fix:** Had noticeable delay on launching an app (foot terminal) via keybind on Void Linux (non-systemd distro), compared to launching it directly from a terminal instance.  

Have tested these changes locally on my daily driver setup for about a week now, and the build in reliable.  