### PR TITLE
fix: warp cursor to newly spawned window

### DIFF
--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -2683,6 +2683,10 @@ void setmon(Client *c, Monitor *m, uint32_t newtags, bool focus) {
 
 	if (focus && !client_is_x11_popup(c)) {
 		focusclient(focustop(selmon), 1);
+
+		if (config.warpcursor && selmon && selmon->sel == c) {
+			warp_cursor(c);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #1334. Warp cursor to window on spawn, making it consistent to how it already warps with keyboard focus changes.

Unsure whether this was left out on purpose. If it was, it can be gated behind a new config option.
