### PR TITLE
feat: monocle layout client count, like in dwm

### DIFF
--- a/src/layout/horizontal.h
+++ b/src/layout/horizontal.h
@@ -584,10 +584,25 @@ void deck(Monitor *m) {
 	}
 }
 
+extern char monocle_symbol[16];
+
 void // 17
 monocle(Monitor *m) {
 	Client *c = NULL;
 	struct wlr_box geom;
+	int n = 0;
+
+	// count visible clients
+	wl_list_for_each(c, &clients, link) {
+		if (VISIBLEON(c, m) && ISFAKETILED(c))
+			n++;
+	}
+
+	// dynamically update the global monocle symbol buffer
+	if (n > 0)
+		snprintf(monocle_symbol, sizeof(monocle_symbol), "[%d]", n);
+	else
+		snprintf(monocle_symbol, sizeof(monocle_symbol), "[M]");
 
 	int32_t cur_gappov = enablegaps ? m->gappov : 0;
 	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -35,13 +35,16 @@ enum {
 	VERTICAL_FAIR,
 };
 
+// client count in monocle layout
+char monocle_symbol[16] = "[M]";
+
 Layout layouts[] = {
 	// 最少两个,不能删除少于两个
 	/* symbol     arrange function   name */
 	{"T", tile, "tile", TILE},						 // 平铺布局
 	{"S", scroller, "scroller", SCROLLER},			 // 滚动布局
 	{"G", grid, "grid", GRID},						 // 格子布局
-	{"M", monocle, "monocle", MONOCLE},				 // 单屏布局
+	{monocle_symbol, monocle, "monocle", MONOCLE},	 // 单屏布局
 	{"K", deck, "deck", DECK},						 // 卡片布局
 	{"CT", center_tile, "center_tile", CENTER_TILE}, // 居中布局
 	{"RT", right_tile, "right_tile", RIGHT_TILE},	 // 右布局


### PR DESCRIPTION
### Summary
**Feature**: Instead of a default `M` for monocle layout, it now gives `[num]`, num being the number of clients open in that tag. This is similar to how dwm displays it's monocle layout, and is very handy if used with a bar like waybar.