### PR TITLE
Feat: Add Layout Binds

### DIFF
--- a/docs/bindings/keys.md
+++ b/docs/bindings/keys.md
@@ -89,6 +89,8 @@ bind=none,Super_L,spawn,rofi -show run
 bindr=Super,Super_L,spawn,rofi -show run
 ```
 
+
+
 ## Dispatchers List
 
 ### Window Management
@@ -204,6 +206,34 @@ It is formed by tag numbers `1`–`9`, optionally combined with `|`.
 | `disable_monitor` | `monitor_spec` | remove monitor. Accepts a [monitor spec](/docs/configuration/monitors#monitor-spec-format). |
 | `enable_monitor` | `monitor_spec` | add monitor. Accepts a [monitor spec](/docs/configuration/monitors#monitor-spec-format). |
 | `toggle_monitor` | `monitor_spec` | Toggle monitor add/remove. Accepts a [monitor spec](/docs/configuration/monitors#monitor-spec-format). |
+
+### Layout Binds
+
+you can bind dispatcher actions to trigger on various layout events:
+```ini
+layoutbind=scroller,switchto,setkeymode,scroller
+layoutbind=dwindle,switchto,setkeymode,dwindle
+layoutbind=dwindle,switchfrom,toggle_all_floating
+```
+the format is `layoutname,event,dispatcher,args`
+
+event options:
+|event|description|
+|:---|:---|
+|switchto | triggers when explicitly switching to this layout (layout_cycle and setlayout dispatchers)|
+|switchfrom | triggers when explicitly switching away from this layout (layout_cycle and setlayout dispatchers)|
+|entry | triggers whenever the layout is updated to this layout (includes tag switch and monitor change)|
+|exit | triggers whenever the layout is updated away from this layout (includes tag switch and monitor change)|
+
+explicit switches:
+ - setlayout dispatcher (all 4 trigger, same-layout retriggers)
+ - cyclelayout dispatcher (all 4 trigger, same-layout retriggers)
+ - compositor start (switchto and entry trigger)
+other switches:
+ - changing tag (entry/exit trigger, only if tags differ)
+ - moving focus between monitor (entry/exit trigger, only if tags of focused clients differ)
+
+
 
 ### Media Controls
 

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -56,6 +56,22 @@ typedef struct {
 	int file_index;
 } KeyBinding;
 
+typedef enum {
+	LAYOUT_BIND_ON,
+	LAYOUT_BIND_OFF,
+	LAYOUT_BIND_ENTRY,
+	LAYOUT_BIND_EXIT,
+} LayoutBindEvent;
+
+typedef struct {
+	char *layout_name;
+	LayoutBindEvent event;
+	void (*func)(const Arg *);
+	Arg arg;
+	int line_number;
+	int file_index;
+} LayoutBinding;
+
 typedef struct {
 	char *type;
 	char *value;
@@ -472,6 +488,9 @@ typedef struct {
 
 	KeyBinding *key_bindings;
 	int32_t key_bindings_count;
+
+	LayoutBinding *layout_bindings;
+	int32_t layout_bindings_count;
 
 	MouseBinding *mouse_bindings;
 	int32_t mouse_bindings_count;
@@ -3206,6 +3225,109 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 		} else {
 			config->key_bindings_count++;
 		}
+	} else if (strcmp(key, "layoutbind") == 0){
+		config->layout_bindings = 
+			realloc(config->layout_bindings,
+				(config->layout_bindings_count + 1) * sizeof(LayoutBinding));
+		if (!config->layout_bindings) {
+			mango_error(false, WLR_ERROR, "Failed to allocate " "memory for layout bindings\n");
+			return false;
+		}
+
+		LayoutBinding *binding = 
+			&config->layout_bindings[config->layout_bindings_count];
+		memset(binding, 0, sizeof(LayoutBinding));
+		binding->line_number = line_number;
+		binding->file_index = current_file_index;
+		char layout_str[256], event_str[256], func_name[256], 
+			arg_value[256] = "0\0", arg_value2[256] = "0\0",
+			arg_value3[256] = "0\0", arg_value4[256] = "0\0",
+			arg_value5[256] = "0\0";
+		if (sscanf(value,
+				   "%255[^,],%255[^,],%255[^,],%255[^,],%255[^,],%255[^"
+				   ",],%255["
+				   "^,],%255[^\n]",
+				   layout_str, event_str, func_name, arg_value, arg_value2,
+				   arg_value3, arg_value4, arg_value5) < 3) {
+			mango_error(false, WLR_ERROR,
+						"Invalid layoutbind "
+						"format: "
+						"%s\n",
+						value);
+			return false;
+		}
+		trim_whitespace(layout_str);
+		trim_whitespace(event_str);
+		trim_whitespace(func_name);
+		trim_whitespace(arg_value);
+		trim_whitespace(arg_value2);
+		trim_whitespace(arg_value3);
+		trim_whitespace(arg_value4);
+		trim_whitespace(arg_value5);
+		int32_t check_index;
+		bool layout_found = false;
+		for (check_index = 0; check_index < LENGTH(layouts); check_index++) {
+			if (strcmp(layouts[check_index].name, layout_str) == 0) {
+				layout_found = true;
+				break;
+			}
+		}
+		if (!layout_found) {
+			mango_error(false, WLR_ERROR, "unknown layout in layoutbind: %s", layout_str);
+			return false;
+		}
+
+		
+
+		if (strcmp(event_str, "switchto") == 0) {
+			binding->event = LAYOUT_BIND_ON;
+		} else if (strcmp(event_str, "switchfrom") == 0) {
+			binding->event = LAYOUT_BIND_OFF;
+		} else if (strcmp(event_str, "entry") == 0) {
+			binding->event = LAYOUT_BIND_ENTRY;
+		} else if (strcmp(event_str, "exit") == 0) {
+			binding->event = LAYOUT_BIND_EXIT;
+		} else {
+			mango_error(false, WLR_ERROR,"Invalid layoutbind event: %s", event_str);
+			return false;
+
+		}
+
+		binding->arg.i = 0;
+		binding->arg.i2 = 0;
+		binding->arg.f = 0.0f;
+		binding->arg.f2 = 0.0f;
+		binding->arg.ui = 0;
+		binding->arg.ui2 = 0;
+		binding->arg.v = NULL;
+		binding->arg.v2 = NULL;
+		binding->arg.v3 = NULL;
+		binding->arg.tc = NULL;
+		binding->func = parse_func_name(func_name, &binding->arg, arg_value, arg_value2, arg_value3, arg_value4, arg_value5);
+
+		if (!binding->func) {
+			if (binding->arg.v) {
+				free(binding->arg.v);
+				binding->arg.v = NULL;
+			}
+			if (binding->arg.v2) {
+				free(binding->arg.v2);
+				binding->arg.v2 = NULL;
+			}
+			if (binding->arg.v3) {
+				free(binding->arg.v3);
+				binding->arg.v3 = NULL;
+			}
+			mango_error(false, WLR_ERROR, "Unknown dispatch in layoutbind: %s", func_name);
+			return false;
+		} else {
+			binding->layout_name = strdup(layout_str);
+			config->layout_bindings_count++;
+		}
+
+		
+		
+
 
 	} else if (strncmp(key, "mousebind", 9) == 0) {
 		config->mouse_bindings =
@@ -4020,6 +4142,30 @@ void free_config(void) {
 		config.key_bindings = NULL;
 		config.key_bindings_count = 0;
 	}
+	if (config.layout_bindings) {
+		for (i = 0; i < config.layout_bindings_count; i++) {
+			if (config.layout_bindings[i].arg.v) {
+				free((void *)config.layout_bindings[i].arg.v);
+				config.layout_bindings[i].arg.v = NULL;
+			}
+			if (config.layout_bindings[i].arg.v2) {
+				free((void *)config.layout_bindings[i].arg.v2);
+				config.layout_bindings[i].arg.v2 = NULL;
+			}
+			if (config.layout_bindings[i].arg.v3) {
+				free((void *)config.layout_bindings[i].arg.v3);
+				config.layout_bindings[i].arg.v3 = NULL;
+			}
+			if (config.layout_bindings[i].layout_name) {
+				free(config.layout_bindings[i].layout_name);
+				config.layout_bindings[i].layout_name = NULL;
+			}
+		}
+		
+		free(config.layout_bindings);
+		config.layout_bindings = NULL;
+		config.layout_bindings_count = 0;
+	}
 
 	// 释放 mouse_bindings
 	if (config.mouse_bindings) {
@@ -4799,6 +4945,8 @@ bool parse_config(void) {
 	config.device_rules_count = 0;
 	config.key_bindings = NULL;
 	config.key_bindings_count = 0;
+	config.layout_bindings = NULL;
+	config.layout_bindings_count = 0;
 	config.mouse_bindings = NULL;
 	config.mouse_bindings_count = 0;
 	config.axis_bindings = NULL;

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -764,6 +764,24 @@ void restore_minimized(const Arg *arg) {
 	return;
 }
 
+static void run_layout_binds(const char *layout_name, LayoutBindEvent event) {
+	int32_t index;
+
+	if (!selmon)
+		return;
+
+	for (index = 0; index < config.layout_bindings_count; index++) {
+		LayoutBinding *bind = &config.layout_bindings[index];
+		if (bind->event == event &&
+			bind->layout_name &&
+			strcmp(bind->layout_name, layout_name) == 0 &&
+			bind->func) {
+				bind->func(&bind->arg);
+			}
+	}
+}
+
+
 void setlayout(const Arg *arg) {
 	int32_t jk;
 	if (!selmon)
@@ -771,10 +789,20 @@ void setlayout(const Arg *arg) {
 
 	for (jk = 0; jk < LENGTH(layouts); jk++) {
 		if (strcmp(layouts[jk].name, arg->v) == 0) {
+			const Layout *oldlayout = selmon->pertag->ltidxs[selmon->pertag->curtag];
+			
+
 			selmon->pertag->ltidxs[selmon->pertag->curtag] = &layouts[jk];
 			clear_fullscreen_and_maximized_state(selmon);
 			arrange(selmon, false, false);
 			printstatus(IPC_WATCH_ARRANGGE);
+			
+			run_layout_binds(oldlayout->name, LAYOUT_BIND_EXIT);
+			run_layout_binds(oldlayout->name, LAYOUT_BIND_OFF);
+			run_layout_binds(arg->v, LAYOUT_BIND_ENTRY);
+			run_layout_binds(arg->v, LAYOUT_BIND_ON);
+		
+			
 			return;
 		}
 	}
@@ -1271,6 +1299,8 @@ void switch_layout(const Arg *arg) {
 	if (!selmon)
 		return;
 
+	const Layout *oldlayout = selmon->pertag->ltidxs[selmon->pertag->curtag];
+
 	if (config.circle_layout_count != 0) {
 		for (jk = 0; jk < config.circle_layout_count; jk++) {
 
@@ -1304,6 +1334,13 @@ void switch_layout(const Arg *arg) {
 		clear_fullscreen_and_maximized_state(selmon);
 		arrange(selmon, false, false);
 		printstatus(IPC_WATCH_ARRANGGE);
+		const Layout *newlayout = selmon->pertag->ltidxs[selmon->pertag->curtag];
+		run_layout_binds(oldlayout->name, LAYOUT_BIND_EXIT);
+		run_layout_binds(oldlayout->name, LAYOUT_BIND_OFF);
+		run_layout_binds(newlayout->name, LAYOUT_BIND_ENTRY);
+		run_layout_binds(newlayout->name, LAYOUT_BIND_ON);
+		
+		
 		return;
 	}
 
@@ -1315,6 +1352,11 @@ void switch_layout(const Arg *arg) {
 			clear_fullscreen_and_maximized_state(selmon);
 			arrange(selmon, false, false);
 			printstatus(IPC_WATCH_ARRANGGE);
+			const Layout *newlayout = selmon->pertag->ltidxs[selmon->pertag->curtag];
+			run_layout_binds(oldlayout->name, LAYOUT_BIND_EXIT);
+			run_layout_binds(oldlayout->name, LAYOUT_BIND_OFF);
+			run_layout_binds(newlayout->name, LAYOUT_BIND_ENTRY);
+			run_layout_binds(newlayout->name, LAYOUT_BIND_ON);
 			return;
 		}
 	}

--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -2380,10 +2380,18 @@ void focusclient(Client *c, int32_t lift) {
 			selmon->sel->foreign_toplevel, false);
 	}
 
+	
+
 	if (c && !c->iskilling && !client_is_unmanaged(c) && c->mon) {
 
 		last_focus_client = selmon ? selmon->sel : NULL;
+		const Layout *prev_layout = selmon ? selmon->pertag->ltidxs[selmon->pertag->curtag]: NULL;
 		selmon = c->mon;
+		const Layout *new_layout = selmon->pertag->ltidxs[selmon->pertag->curtag];
+		if (prev_layout && strcmp(prev_layout->name, new_layout->name) !=0) {
+			run_layout_binds(prev_layout->name, LAYOUT_BIND_EXIT);
+			run_layout_binds(new_layout->name, LAYOUT_BIND_ENTRY);
+		}
 		selmon->prevsel = selmon->sel;
 		selmon->sel = c;
 		c->isfocusing = true;
@@ -2534,6 +2542,7 @@ void client_active(Client *c) {
 void view_in_mon(const Arg *arg, bool want_animation, Monitor *m,
 				 bool changefocus) {
 	uint32_t i, tmptag;
+	
 
 	if (!m || (arg->ui != (~0 & TAGMASK) && m->isoverview)) {
 		return;
@@ -2542,6 +2551,7 @@ void view_in_mon(const Arg *arg, bool want_animation, Monitor *m,
 	if (arg->ui == 0) {
 		return;
 	}
+	const Layout *oldlayout = m->pertag->ltidxs[m->pertag->curtag];
 
 	if (arg->ui == UINT32_MAX) {
 		if (m->tagset[0] != m->tagset[1]) {
@@ -2585,6 +2595,12 @@ void view_in_mon(const Arg *arg, bool want_animation, Monitor *m,
 	}
 
 toggleseltags:
+	const Layout *newlayout = m->pertag->ltidxs[m->pertag->curtag];
+
+	if (strcmp (oldlayout->name, newlayout->name) != 0) {
+		run_layout_binds(oldlayout->name, LAYOUT_BIND_EXIT);
+		run_layout_binds(newlayout->name, LAYOUT_BIND_ENTRY);
+	}
 
 	if (changefocus)
 		focusclient(focustop(m), 1);

--- a/src/mango.c
+++ b/src/mango.c
@@ -1541,6 +1541,10 @@ run(char *startup_cmd, int readiness_fd) {
 	run_exec();
 	run_exec_once();
 
+	const char *initlayout = selmon->pertag->ltidxs[selmon->pertag->curtag]->name;
+	run_layout_binds(initlayout, LAYOUT_BIND_ENTRY);
+	run_layout_binds(initlayout, LAYOUT_BIND_ON);
+
 	/*
 	 * If running inside supervision suite like s6, notify about successfull
 	 * startup by writing \n to the provided file descriptor and closing it


### PR DESCRIPTION
This feature i came up with based on some conversations in the discord.

new config option:

layoutbind=layout,event,dispatcher,args

events are: switchto/switchfrom (explicit, only trigger on dispatch events and compositor initialization) and entry/exit (implicit, will also trigger on tag switch and keyboard focus switch)

re-uses the same dispatcher logic from keybinds, and supports all the same dispatchers. 

this allows for layout-specific daemons as well as communications over IPC back to the user's shell when the layout changes. without taking into account external applications, this also allows things like gaps to be toggled for specific modes and allows for layout-specific keymodes. 

