### PR TITLE
fix(config): strip enclosing quotes from string configuration values

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -575,6 +575,20 @@ void trim_whitespace(char *str) {
 	}
 }
 
+// Helper function to strip enclosing single or double quotes
+void strip_quotes(char *str) {
+	if (str == NULL || *str == '\0')
+		return;
+
+	size_t len = strlen(str);
+	if (len >= 2 && ((str[0] == '"' && str[len - 1] == '"') ||
+					 (str[0] == '\'' && str[len - 1] == '\''))) {
+		str[len - 1] = '\0';
+		memmove(str, str + 1, len - 1);
+		trim_whitespace(str);
+	}
+}
+
 // remove comment, support double quote inside "#xxx" or '#xxx' not be treated
 // as comment
 void remove_comment(char *str) {
@@ -3571,6 +3585,7 @@ bool parse_config_line(Config *config, const char *line, int line_number) {
 
 	trim_whitespace(key);
 	trim_whitespace(value);
+	strip_quotes(value);
 
 	return parse_option(config, key, value, line_number);
 }


### PR DESCRIPTION
If you set a string value with quotes in `config.conf` like:

```ini
cursor_theme="Adwaita"
```

the parser currently keeps the quotes literally via `strdup(value)`. When it gets passed to `wlr_xcursor_manager_create()`, wlroots looks for a folder named `"Adwaita"` (with the quote characters), fails to find it, and falls back to the default cursor.

This adds a small `strip_quotes()` helper in `parse_config.h` right after `trim_whitespace(value)` so matching single or double quotes get stripped.

- Tested with `nix build .`
- Formatted with `./format.sh`
- Squashed into a single commit