### PR TITLE
feat: implement special tag overlay workspace (scratchpad)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.cache
 /.vscode
 /result
+/build
 /mango-wlonly
 config.h
 mango

--- a/assets/config.conf
+++ b/assets/config.conf
@@ -128,6 +128,11 @@ gappoh=10
 gappov=10
 scratchpad_width_ratio=0.8
 scratchpad_height_ratio=0.9
+special_dim=0.5
+special_gappih=10
+special_gappiv=10
+special_gappoh=20
+special_gappov=20
 borderpx=4
 rootcolor=0x201b14ff
 bordercolor=0x444444ff
@@ -191,6 +196,9 @@ bind=SUPER,i,minimized,
 bind=SUPER,o,toggleoverlay,
 bind=SUPER+SHIFT,I,restore_minimized
 bind=ALT,z,toggle_scratchpad
+bind=SUPER,s,toggle_special_tag
+bind=SUPER+SHIFT,s,tag_special_tag
+bind=SUPER+CTRL,s,tag_special_silent
 
 # scroller layout
 bind=ALT,e,set_proportion,1.0

--- a/docs/bindings/keys.md
+++ b/docs/bindings/keys.md
@@ -105,9 +105,12 @@ bindr=Super,Super_L,spawn,rofi -show run
 | `toggle_render_border` | - | Toggle border rendering. |
 | `centerwin` | - | Center the floating window. |
 | `minimized` | - | Minimize window to scratchpad. |
-| `restore_minimized` | `0/1` | Restore minimized window to its previous state.(`1` means keep previous tags, `0` means restore to current tags.) |
+| `restore_minimized` | - | Restore minimized window to the currently focused tag. |
 | `toggle_scratchpad` | - | Toggle scratchpad. |
 | `toggle_named_scratchpad` | `appid,title,cmd` | Toggle named scratchpad. Launches app if not running, otherwise shows/hides it. |
+| `toggle_special_tag` | - | Toggle special workspace overlay (tiling scratchpad). |
+| `tag_special_tag` | - | Move focused window to/from the special workspace overlay. |
+| `tag_special_silent` | - | Silently move focused window to/from the special workspace overlay. |
 
 ### Focus & Movement
 

--- a/docs/window-management/rules.md
+++ b/docs/window-management/rules.md
@@ -50,7 +50,7 @@ windowrule=Parameter:Values,Parameter:Values,appid:Values,title:Values
 | `offsetx` | integer | -999-999 | X offset from center (%), 100 is the edge of screen with outer gap |
 | `offsety` | integer | -999-999 | Y offset from center (%), 100 is the edge of screen with outer gap |
 | `monitor` | string | Any | Assign to monitor by [monitor spec](/docs/configuration/monitors#monitor-spec-format) (name, make, model, or serial) |
-| `tags` | mask | `1-9` / `1\|3\|5` | Assign to specific one tag or multiple tags(use `\|` to split multiple tags) |
+| `tags` | mask | `0-9` / `1\|3\|5` | Assign to specific one tag (use `0` for special workspace overlay) or multiple tags (use `\|` to split multiple tags) |
 | `no_force_center` | integer | `0` / `1` | Window does not force center |
 | `isnosizehint` | integer | `0` / `1` | Don't use min size and max size for size hints |
 

--- a/docs/window-management/scratchpad.md
+++ b/docs/window-management/scratchpad.md
@@ -71,3 +71,47 @@ scratchpad_width_ratio=0.8
 scratchpad_height_ratio=0.9
 scratchpadcolor=0x516c93ff
 ```
+
+---
+
+## Special Workspace (Tag 0)
+
+The special workspace (Tag 0) provides an overlay workspace of windows that can be summoned anywhere with full layout support (Scroller, Master/Stack, Dwindle, etc.). When Tag 0 is active, windows from the underlying workspace remain visible in the background, and all windows on the special workspace are displayed above them.
+
+### Keybindings
+
+```ini
+# Toggle the special workspace overlay (Tag 0)
+bind=SUPER,s,toggle_special_tag
+
+# Move focused window to/from the special workspace
+bind=SUPER+SHIFT,s,tag_special_tag
+
+# Silently send active window to the special workspace without switching
+bind=SUPER+CTRL,s,tag_special_silent
+```
+
+### Window Rules for Special Workspace
+
+You can automatically assign applications to launch directly on the special workspace using `tags:0`:
+
+```ini
+# Automatically open Spotify and Discord in the special workspace
+windowrule=tags:0,appid:spotify
+windowrule=tags:0,appid:discord
+```
+
+### Configuration Options
+
+You can configure background dimming and custom layout gaps for the special workspace:
+
+```ini
+# Background dim level when special workspace is active (0.0 to 1.0, default 0.5)
+special_dim=0.5
+
+# Inner and outer gaps for windows on the special workspace
+special_gappih=10
+special_gappiv=10
+special_gappoh=20
+special_gappov=20
+```

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -28,8 +28,14 @@ stdenv.mkDerivation {
   pname = "mango";
   version = "nightly";
 
-  src = builtins.path {
-    path = ../.;
+  src = lib.cleanSourceWith {
+    src = ../.;
+    filter =
+      path: type:
+      let
+        base = baseNameOf (toString path);
+      in
+      (lib.cleanSourceFilter path type) && base != "build" && base != "result";
     name = "source";
   };
 

--- a/src/animation/client.h
+++ b/src/animation/client.h
@@ -60,18 +60,14 @@ struct fx_corner_radii set_client_corner_location(Client *c) {
 }
 
 bool is_horizontal_stack_layout(Monitor *m) {
-	if (m->pertag->curtag &&
-		(m->pertag->ltidxs[m->pertag->curtag]->id == TILE ||
-		 m->pertag->ltidxs[m->pertag->curtag]->id == DECK))
-		return true;
-	return false;
+	uint32_t tag = get_mon_curtag(m);
+	return m->pertag->ltidxs[tag]->id == TILE ||
+		   m->pertag->ltidxs[tag]->id == DECK;
 }
 
 bool is_horizontal_right_stack_layout(Monitor *m) {
-	if (m->pertag->curtag &&
-		m->pertag->ltidxs[m->pertag->curtag]->id == RIGHT_TILE)
-		return true;
-	return false;
+	uint32_t tag = get_mon_curtag(m);
+	return m->pertag->ltidxs[tag]->id == RIGHT_TILE;
 }
 
 int32_t is_special_animation_rule(Client *c) {
@@ -542,7 +538,8 @@ void client_draw_split_border(Client *c, bool hit_no_border,
 	if (c->iskilling || !c->mon || !client_surface(c)->mapped)
 		return;
 
-	const Layout *layout = c->mon->pertag->ltidxs[c->mon->pertag->curtag];
+	uint32_t tag = get_client_tag_idx(c);
+	const Layout *layout = c->mon->pertag->ltidxs[tag];
 
 	if (hit_no_border || !ISTILED(c) || layout->id != DWINDLE ||
 		!config.dwindle_manual_split || c->isfullscreen) {
@@ -553,7 +550,7 @@ void client_draw_split_border(Client *c, bool hit_no_border,
 		return;
 	}
 
-	DwindleNode **root = &c->mon->pertag->dwindle_root[c->mon->pertag->curtag];
+	DwindleNode **root = &c->mon->pertag->dwindle_root[tag];
 	DwindleNode *dnode = dwindle_find_leaf(*root, c);
 	if (!dnode) {
 		wlr_scene_node_set_enabled(&c->splitindicator[0]->node, false);
@@ -748,7 +745,7 @@ void client_set_drop_area(Client *c) {
 	double rel_y = cursor->y - c->geom.y - bw;
 
 	struct wlr_box drop_box;
-	const Layout *cur_layout = c->mon->pertag->ltidxs[c->mon->pertag->curtag];
+	const Layout *cur_layout = c->mon->pertag->ltidxs[get_client_tag_idx(c)];
 	bool dwindle_familiar =
 		cur_layout->id == DWINDLE && config.dwindle_drop_simple_split;
 

--- a/src/animation/tag.h
+++ b/src/animation/tag.h
@@ -49,6 +49,8 @@ void set_arrange_visible(Monitor *m, Client *c, bool want_animation) {
 	if (c->is_logic_hide)
 		return;
 
+	bool was_enabled = c->scene->node.enabled;
+
 	if (!ISTILED(c) || (!c->is_clip_to_hide || !is_scroller_layout(c->mon))) {
 		c->is_clip_to_hide = false;
 		c->is_logic_hide = false;
@@ -58,7 +60,25 @@ void set_arrange_visible(Monitor *m, Client *c, bool want_animation) {
 			wlr_scene_node_set_enabled(&c->scene_surface->node, true);
 	}
 
-	if (!c->animation.tag_from_rule && want_animation &&
+	/* Special workspace clients slide in from above the monitor */
+	if (c->tags & TAG0_MASK) {
+		c->animation.tag_from_rule = false;
+		c->animation.tagouting = false;
+		c->animation.tagouted = false;
+		client_raise_group(c);
+		if (want_animation && config.animations) {
+			c->animation.tagining = true;
+			c->animainit_geom = c->geom;
+			c->animainit_geom.y = c->mon->m.y - c->geom.height;
+		} else {
+			c->animainit_geom.x = c->animation.current.x;
+			c->animainit_geom.y = c->animation.current.y;
+		}
+		resize_apply(c, c->geom, (ResizeOpts){.skip_ov_enter_anim = true});
+		return;
+	}
+
+	if (!was_enabled && !c->animation.tag_from_rule && want_animation &&
 		m->pertag->prevtag != 0 && m->pertag->curtag != 0 &&
 		config.animations) {
 		c->animation.tagining = true;
@@ -132,7 +152,29 @@ void set_arrange_hidden(Monitor *m, Client *c, bool want_animation) {
 		return;
 	}
 
-	if ((c->tags & (1 << (m->pertag->prevtag - 1))) &&
+	/* Special workspace windows should animate out or hide when special
+	 * workspace is not active */
+	if (c->tags & TAG0_MASK) {
+		if (want_animation && config.animations && !c->animation.tagouted &&
+			c->scene->node.enabled) {
+			c->animation.tagouting = true;
+			c->animation.tagining = false;
+			c->pending = c->geom;
+			c->pending.y = c->mon->m.y - c->geom.height;
+			client_raise_group(c);
+			resize(c, c->geom, 0);
+		} else {
+			c->animation.running = false;
+			c->animation.tagouting = false;
+			c->animation.tagining = false;
+			wlr_scene_node_set_enabled(&c->scene->node, false);
+			c->animainit_geom = c->current = c->pending = c->animation.current =
+				c->geom;
+		}
+		return;
+	}
+
+	if (want_animation && (c->tags & (1 << (m->pertag->prevtag - 1))) &&
 		m->pertag->prevtag != 0 && m->pertag->curtag != 0 &&
 		config.animations) {
 		c->animation.tagouting = true;

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -437,10 +437,15 @@ typedef struct {
 	uint32_t gappiv;
 	uint32_t gappoh;
 	uint32_t gappov;
+	uint32_t special_gappih;
+	uint32_t special_gappiv;
+	uint32_t special_gappoh;
+	uint32_t special_gappov;
 	uint32_t borderpx;
 	uint32_t group_bar_height;
 	float scratchpad_width_ratio;
 	float scratchpad_height_ratio;
+	float special_dim;
 	float rootcolor[4];
 	float bordercolor[4];
 	float dropcolor[4];
@@ -1177,8 +1182,11 @@ uint32_t parse_tag_mask(char *str) {
 		token = strtok_r(arg_copy, "|", &saveptr);
 
 		while (token != NULL) {
+			trim_whitespace(token);
 			int32_t num = atoi(token);
-			if (num > 0 && num <= tag_num_MAX) {
+			if (num == 0 && strcmp(token, "0") == 0) {
+				mask |= TAG0_MASK;
+			} else if (num > 0 && num <= tag_num_MAX) {
 				mask |= (1 << (num - 1));
 			}
 			token = strtok_r(NULL, "|", &saveptr);
@@ -1186,6 +1194,10 @@ uint32_t parse_tag_mask(char *str) {
 
 		free(arg_copy);
 	}
+
+	// tag0 and normal tags are exclusive; keep tag0 when mixed
+	if ((mask & TAG0_MASK) && (mask & TAGMASK))
+		mask = TAG0_MASK;
 
 	uint32_t result = 0;
 
@@ -1390,7 +1402,6 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 		func = minimized;
 	} else if (strcmp(func_name, "restore_minimized") == 0) {
 		func = restore_minimized;
-		(*arg).i = atoi(arg_value);
 	} else if (strcmp(func_name, "toggle_scratchpad") == 0) {
 		func = toggle_scratchpad;
 	} else if (strcmp(func_name, "toggle_render_border") == 0) {
@@ -1504,6 +1515,12 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 		(*arg).v = strdup(arg_value);
 		(*arg).v2 = strdup(arg_value2);
 		(*arg).v3 = strdup(arg_value3);
+	} else if (strcmp(func_name, "toggle_special_tag") == 0) {
+		func = toggle_special_tag;
+	} else if (strcmp(func_name, "tag_special_tag") == 0) {
+		func = tag_special_tag;
+	} else if (strcmp(func_name, "tag_special_silent") == 0) {
+		func = tag_special_silent;
 	} else if (strcmp(func_name, "disable_monitor") == 0) {
 		func = disable_monitor;
 		(*arg).v = strdup(arg_value);
@@ -2265,6 +2282,16 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 		config->scratchpad_width_ratio = atof(value);
 	} else if (strcmp(key, "scratchpad_height_ratio") == 0) {
 		config->scratchpad_height_ratio = atof(value);
+	} else if (strcmp(key, "special_dim") == 0) {
+		config->special_dim = atof(value);
+	} else if (strcmp(key, "special_gappih") == 0) {
+		config->special_gappih = atoi(value);
+	} else if (strcmp(key, "special_gappiv") == 0) {
+		config->special_gappiv = atoi(value);
+	} else if (strcmp(key, "special_gappoh") == 0) {
+		config->special_gappoh = atoi(value);
+	} else if (strcmp(key, "special_gappov") == 0) {
+		config->special_gappov = atoi(value);
 	} else if (strcmp(key, "borderpx") == 0) {
 		config->borderpx = atoi(value);
 	} else if (strcmp(key, "group_bar_height") == 0) {
@@ -4415,6 +4442,11 @@ void override_config(void) {
 		CLAMP_FLOAT(config.scratchpad_width_ratio, 0.1f, 1.0f);
 	config.scratchpad_height_ratio =
 		CLAMP_FLOAT(config.scratchpad_height_ratio, 0.1f, 1.0f);
+	config.special_dim = CLAMP_FLOAT(config.special_dim, 0.0f, 1.0f);
+	config.special_gappih = CLAMP_INT(config.special_gappih, 0, 1000);
+	config.special_gappiv = CLAMP_INT(config.special_gappiv, 0, 1000);
+	config.special_gappoh = CLAMP_INT(config.special_gappoh, 0, 1000);
+	config.special_gappov = CLAMP_INT(config.special_gappov, 0, 1000);
 	config.borderpx = CLAMP_INT(config.borderpx, 0, 200);
 	config.group_bar_height = CLAMP_INT(config.group_bar_height, 0, 500);
 	config.smartgaps = CLAMP_INT(config.smartgaps, 0, 1);
@@ -4515,6 +4547,11 @@ void set_value_default() {
 	config.gappov = 10;
 	config.scratchpad_width_ratio = 0.8f;
 	config.scratchpad_height_ratio = 0.9f;
+	config.special_dim = 0.5f;
+	config.special_gappih = 10;
+	config.special_gappiv = 10;
+	config.special_gappoh = 20;
+	config.special_gappov = 20;
 
 	config.scroller_structs = 20;
 	config.scroller_default_proportion = 0.9f;
@@ -5094,7 +5131,7 @@ void reapply_master(void) {
 
 	int32_t i;
 	Monitor *m = NULL;
-	for (i = 0; i <= config.tag_num; i++) {
+	for (i = 0; i < PERTAG_SLOTS; i++) {
 		wl_list_for_each(m, &mons, link) {
 			if (!m->wlr_output->enabled) {
 				continue;
@@ -5105,6 +5142,10 @@ void reapply_master(void) {
 			m->gappiv = config.gappiv;
 			m->gappoh = config.gappoh;
 			m->gappov = config.gappov;
+			m->special_gappih = config.special_gappih;
+			m->special_gappiv = config.special_gappiv;
+			m->special_gappoh = config.special_gappoh;
+			m->special_gappov = config.special_gappov;
 		}
 	}
 }
@@ -5180,6 +5221,8 @@ void parse_tagrule(Monitor *m) {
 	// Set defaults for every tag.
 	for (i = 0; i <= config.tag_num; i++)
 		tag_slot_set_defaults(m, i);
+	// dedicated state slot for the all-tags view
+	tag_slot_set_defaults(m, PERTAG_ALL_TAGS_IDX);
 
 	for (i = 0; i < config.tag_rules_count; i++) {
 		const ConfigTagRule *tr = &config.tag_rules[i];

--- a/src/dispatch/bind_declare.h
+++ b/src/dispatch/bind_declare.h
@@ -89,3 +89,6 @@ void dwindle_split_horizontal(const Arg *arg);
 void dwindle_split_vertical(const Arg *arg);
 void dwindle_toggle_current_split(const Arg *arg);
 void focusid(const Arg *arg);
+void toggle_special_tag(const Arg *arg);
+void tag_special_tag(const Arg *arg);
+void tag_special_silent(const Arg *arg);

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -8,7 +8,11 @@ void bind_to_view(const Arg *arg) {
 		if (selmon->pertag->prevtag)
 			target = 1 << (selmon->pertag->prevtag - 1);
 		else
-			target = 0;
+			// prevtag==0: previous view was all-tags or special,
+			// decide by the other tagset
+			target = (selmon->tagset[selmon->seltags ^ 1] & TAG0_MASK)
+						 ? TAG0_MASK
+						 : 0;
 	}
 
 	if (!config.view_current_to_back &&
@@ -21,6 +25,12 @@ void bind_to_view(const Arg *arg) {
 			target = 1 << (selmon->pertag->prevtag - 1);
 		else
 			target = 0;
+	}
+
+	// TAG0_MASK is INT_MIN too; handle it before the all-tags branch
+	if (target == TAG0_MASK) {
+		view(&(Arg){.ui = target, .i = arg->i}, true);
+		return;
 	}
 
 	if (target == 0 || (int32_t)target == INT_MIN) {
@@ -87,7 +97,12 @@ void destroy_all_virtual_output(const Arg *arg) {
 }
 
 void defaultgaps(const Arg *arg) {
-	setgaps(config.gappoh, config.gappov, config.gappih, config.gappiv);
+	if (selmon && is_special_active(selmon)) {
+		setgaps(config.special_gappoh, config.special_gappov,
+				config.special_gappih, config.special_gappiv);
+	} else {
+		setgaps(config.gappoh, config.gappov, config.gappih, config.gappiv);
+	}
 	return;
 }
 
@@ -147,13 +162,16 @@ void focusdir(const Arg *arg) {
 		if (config.warpcursor)
 			warp_cursor(c);
 	} else {
-		if (config.focus_cross_tag) {
-			if (arg->i == LEFT || arg->i == UP)
-				view_shift_tag_have_client(&(Arg){0}, -1);
-			if (arg->i == RIGHT || arg->i == DOWN)
-				view_shift_tag_have_client(&(Arg){0}, 1);
-		} else if (config.focus_cross_monitor) {
-			focusmon(arg);
+		// no cross-tag/monitor jumps inside the special workspace
+		if (!is_special_active(selmon)) {
+			if (config.focus_cross_tag) {
+				if (arg->i == LEFT || arg->i == UP)
+					view_shift_tag_have_client(&(Arg){0}, -1);
+				if (arg->i == RIGHT || arg->i == DOWN)
+					view_shift_tag_have_client(&(Arg){0}, 1);
+			} else if (config.focus_cross_monitor) {
+				focusmon(arg);
+			}
 		}
 	}
 	return;
@@ -178,14 +196,16 @@ void focus_window_or_workspace(const Arg *arg) {
 		return;
 	}
 
-	int dir = arg->i;
+	if (!is_special_active(selmon)) {
+		int dir = arg->i;
 
-	if (dir == LEFT || dir == UP) {
-		if (!view_shift_tag_have_client(&(Arg){0}, -1))
-			view_shift_tag(&(Arg){0}, -1);
-	} else if (dir == RIGHT || dir == DOWN) {
-		if (!view_shift_tag_have_client(&(Arg){0}, 1))
-			view_shift_tag(&(Arg){0}, 1);
+		if (dir == LEFT || dir == UP) {
+			if (!view_shift_tag_have_client(&(Arg){0}, -1))
+				view_shift_tag(&(Arg){0}, -1);
+		} else if (dir == RIGHT || dir == DOWN) {
+			if (!view_shift_tag_have_client(&(Arg){0}, 1))
+				view_shift_tag(&(Arg){0}, 1);
+		}
 	}
 
 	return;
@@ -446,8 +466,9 @@ void groupfocus(const Arg *arg) {
 void incnmaster(const Arg *arg) {
 	if (!arg || !selmon)
 		return;
-	selmon->pertag->nmasters[selmon->pertag->curtag] =
-		MANGO_MAX(selmon->pertag->nmasters[selmon->pertag->curtag] + arg->i, 0);
+	uint32_t tag = get_mon_curtag(selmon);
+	selmon->pertag->nmasters[tag] =
+		MANGO_MAX(selmon->pertag->nmasters[tag] + arg->i, 0);
 	arrange(selmon, false, false);
 	return;
 }
@@ -513,14 +534,14 @@ void setmfact(const Arg *arg) {
 	Client *c = NULL;
 
 	if (!arg || !selmon ||
-		!selmon->pertag->ltidxs[selmon->pertag->curtag]->arrange)
+		!selmon->pertag->ltidxs[get_mon_curtag(selmon)]->arrange)
 		return;
-	f = arg->f < 1.0 ? arg->f + selmon->pertag->mfacts[selmon->pertag->curtag]
+	f = arg->f < 1.0 ? arg->f + selmon->pertag->mfacts[get_mon_curtag(selmon)]
 					 : arg->f - 1.0;
 	if (f < 0.1 || f > 0.9)
 		return;
 
-	selmon->pertag->mfacts[selmon->pertag->curtag] = f;
+	selmon->pertag->mfacts[get_mon_curtag(selmon)] = f;
 	wl_list_for_each(c, &clients, link) {
 		if (VISIBLEON(c, selmon) && ISTILED(c)) {
 			c->master_mfact_per = f;
@@ -725,43 +746,61 @@ void resizewin(const Arg *arg) {
 }
 
 void restore_minimized(const Arg *arg) {
-	Client *c = arg->tc ? arg->tc : (selmon ? selmon->sel : NULL);
-
 	if (selmon && selmon->isoverview)
 		return;
 
-	if (c && c->is_in_scratchpad && c->is_scratchpad_show) {
-		client_pending_minimized_state(c, 0);
-		c->is_scratchpad_show = 0;
-		c->is_in_scratchpad = 0;
-		c->isnamedscratchpad = 0;
-		setborder_color(c);
-		return;
-	}
+	Client *c = NULL;
+	Client *focused = selmon ? selmon->sel : NULL;
+	if (!focused && selmon)
+		focused = focustop(selmon);
 
-	bool is_keep_before_tag = arg->i == 1 ? true : false;
-
-	wl_list_for_each(c, &clients, link) {
-		if (c->isminimized && !c->isnamedscratchpad) {
-			c->is_scratchpad_show = 0;
-			c->is_in_scratchpad = 0;
-			c->isnamedscratchpad = 0;
-			c->isminimized = 0;
-
-			if (!is_keep_before_tag) {
-				c->mon = selmon;
-				c->oldtags = c->tags = selmon->tagset[selmon->seltags];
-			} else {
-				selmon = c->mon;
+	/* 1. If focused window or any shown scratchpad exists, evict it */
+	if (focused && focused->is_in_scratchpad && focused->is_scratchpad_show) {
+		c = focused;
+	} else {
+		Client *tc = NULL;
+		wl_list_for_each(tc, &clients, link) {
+			if ((tc->mon == selmon || config.scratchpad_cross_monitor) &&
+				tc->is_in_scratchpad && tc->is_scratchpad_show) {
+				c = tc;
+				break;
 			}
-
-			show_hide_client(c);
-			setborder_color(c);
-			warp_cursor(c);
-			return;
 		}
 	}
-	return;
+
+	/* 2. Otherwise, find a minimized window to restore */
+	if (!c) {
+		wl_list_for_each(c, &clients, link) {
+			if (c->isminimized && !c->isnamedscratchpad)
+				break;
+		}
+		if (&c->link == &clients)
+			c = NULL;
+	}
+
+	if (!c)
+		return;
+
+	/* Clear scratchpad & minimized state */
+	c->is_scratchpad_show = 0;
+	c->is_in_scratchpad = 0;
+	c->isnamedscratchpad = 0;
+	c->isminimized = 0;
+	client_pending_minimized_state(c, 0);
+	c->iscustomsize = 0;
+
+	/* Restore to the tag where a window currently is focused */
+	c->tags = (focused && focused != c && focused->tags)
+				  ? focused->tags
+				  : selmon->tagset[selmon->seltags];
+	c->oldtags = c->tags;
+	c->mon = selmon;
+
+	setfloating(c, 0);
+	setborder_color(c);
+	arrange(c->mon, false, false);
+	focusclient(c, 1);
+	warp_cursor(c);
 }
 
 void setlayout(const Arg *arg) {
@@ -771,7 +810,7 @@ void setlayout(const Arg *arg) {
 
 	for (jk = 0; jk < LENGTH(layouts); jk++) {
 		if (strcmp(layouts[jk].name, arg->v) == 0) {
-			selmon->pertag->ltidxs[selmon->pertag->curtag] = &layouts[jk];
+			selmon->pertag->ltidxs[get_mon_curtag(selmon)] = &layouts[jk];
 			clear_fullscreen_and_maximized_state(selmon);
 			arrange(selmon, false, false);
 			printstatus(IPC_WATCH_ARRANGGE);
@@ -812,7 +851,7 @@ void set_proportion(const Arg *arg) {
 		return;
 
 	Monitor *m = tc->mon;
-	uint32_t tag = m->pertag->curtag;
+	uint32_t tag = get_mon_curtag(m);
 	struct TagScrollerState *st = m->pertag->scroller_state[tag];
 	struct ScrollerStackNode *node = NULL;
 
@@ -859,7 +898,7 @@ void switch_proportion_preset(const Arg *arg) {
 		return;
 
 	Monitor *m = tc->mon;
-	uint32_t tag = m->pertag->curtag;
+	uint32_t tag = get_mon_curtag(m);
 	struct TagScrollerState *st = m->pertag->scroller_state[tag];
 	struct ScrollerStackNode *node = NULL;
 
@@ -1097,7 +1136,7 @@ void centerwin(const Arg *arg) {
 		return;
 
 	Client *stack_head = scroll_get_stack_head_client(c);
-	if (selmon->pertag->ltidxs[selmon->pertag->curtag]->id == SCROLLER) {
+	if (selmon->pertag->ltidxs[get_mon_curtag(selmon)]->id == SCROLLER) {
 		stack_head->geom.x =
 			selmon->w.x + (selmon->w.width - stack_head->geom.width) / 2;
 	} else {
@@ -1265,16 +1304,16 @@ void switch_layout(const Arg *arg) {
 	if (!selmon)
 		return;
 
+	uint32_t tag = get_mon_curtag(selmon);
+
 	if (config.circle_layout_count != 0) {
 		for (jk = 0; jk < config.circle_layout_count; jk++) {
 
-			len = MANGO_MAX(
-				strlen(config.circle_layout[jk]),
-				strlen(selmon->pertag->ltidxs[selmon->pertag->curtag]->name));
+			len = MANGO_MAX(strlen(config.circle_layout[jk]),
+							strlen(selmon->pertag->ltidxs[tag]->name));
 
 			if (strncmp(config.circle_layout[jk],
-						selmon->pertag->ltidxs[selmon->pertag->curtag]->name,
-						len) == 0) {
+						selmon->pertag->ltidxs[tag]->name, len) == 0) {
 				target_layout_name = jk == config.circle_layout_count - 1
 										 ? config.circle_layout[0]
 										 : config.circle_layout[jk + 1];
@@ -1290,7 +1329,7 @@ void switch_layout(const Arg *arg) {
 			len =
 				MANGO_MAX(strlen(layouts[ji].name), strlen(target_layout_name));
 			if (strncmp(layouts[ji].name, target_layout_name, len) == 0) {
-				selmon->pertag->ltidxs[selmon->pertag->curtag] = &layouts[ji];
+				selmon->pertag->ltidxs[tag] = &layouts[ji];
 
 				break;
 			}
@@ -1302,9 +1341,8 @@ void switch_layout(const Arg *arg) {
 	}
 
 	for (jk = 0; jk < LENGTH(layouts); jk++) {
-		if (strcmp(layouts[jk].name,
-				   selmon->pertag->ltidxs[selmon->pertag->curtag]->name) == 0) {
-			selmon->pertag->ltidxs[selmon->pertag->curtag] =
+		if (strcmp(layouts[jk].name, selmon->pertag->ltidxs[tag]->name) == 0) {
+			selmon->pertag->ltidxs[tag] =
 				jk == LENGTH(layouts) - 1 ? &layouts[0] : &layouts[jk + 1];
 			clear_fullscreen_and_maximized_state(selmon);
 			arrange(selmon, false, false);
@@ -1403,7 +1441,9 @@ void tagsilent(const Arg *arg) {
 	if (!target_client)
 		return;
 
-	target_client->tags = arg->ui & TAGMASK;
+	target_client->tags =
+		(arg->ui & TAG0_MASK) ? TAG0_MASK : (arg->ui & TAGMASK);
+	client_reparent_group(target_client);
 	wl_list_for_each(fc, &clients, link) {
 		if (fc && fc != target_client && target_client->tags & fc->tags &&
 			ISFULLSCREEN(fc) && !target_client->isfloating) {
@@ -1519,6 +1559,69 @@ void toggle_scratchpad(const Arg *arg) {
 	}
 	return;
 }
+
+// toggle the special workspace view on a given monitor
+static void toggle_special_tag_mon(Monitor *m) {
+	if (!m || m->isoverview)
+		return;
+
+	selmon = m;
+	if (is_special_active(m)) {
+		/* Toggle back to previous tagset (supports multi-tag views) */
+		uint32_t prev_set = m->tagset[m->seltags ^ 1] & TAGMASK;
+		uint32_t target =
+			prev_set
+				? prev_set
+				: (m->pertag->prevtag ? (1 << (m->pertag->prevtag - 1)) : 1);
+		view(&(Arg){.ui = target}, true);
+	} else {
+		/* Switch to tag 0 */
+		view(&(Arg){.ui = TAG0_MASK}, true);
+	}
+}
+
+void toggle_special_tag(const Arg *arg) {
+	Monitor *m = (arg && arg->tc && arg->tc->mon) ? arg->tc->mon : selmon;
+	toggle_special_tag_mon(m);
+}
+
+static void tag_special_tag_internal(const Arg *arg, bool silent) {
+	if (!selmon)
+		return;
+	Client *c = arg->tc ? arg->tc : selmon->sel;
+	if (!c)
+		return;
+
+	Monitor *m = c->mon ? c->mon : selmon;
+	if (c->tags & TAG0_MASK) {
+		/* Return window from tag 0 to normal tag */
+		uint32_t target =
+			(m->pertag->prevtag > 0)
+				? (1 << (m->pertag->prevtag - 1))
+				: ((m->pertag->curtag > 0) ? (1 << (m->pertag->curtag - 1))
+										   : 1);
+		if (silent)
+			tagsilent(&(Arg){.ui = target, .tc = c});
+		else
+			tag(&(Arg){.ui = target, .tc = c});
+
+	} else {
+		/* Send window to tag 0 */
+		if (silent)
+			tagsilent(&(Arg){.ui = TAG0_MASK, .tc = c});
+		else {
+			tag(&(Arg){.ui = TAG0_MASK, .tc = c});
+			/* Switch to tag 0 so user sees the window */
+			if (!is_special_active(m)) {
+				toggle_special_tag(&(Arg){0});
+			}
+		}
+	}
+}
+
+void tag_special_tag(const Arg *arg) { tag_special_tag_internal(arg, false); }
+
+void tag_special_silent(const Arg *arg) { tag_special_tag_internal(arg, true); }
 
 void togglefakefullscreen(const Arg *arg) {
 	if (!selmon)
@@ -1644,17 +1747,27 @@ void toggletag(const Arg *arg) {
 	Client *sel = arg->tc ? arg->tc : focustop(selmon);
 	if (!sel)
 		return;
+	// special workspace windows only belong to tag0; use tag_special_tag to
+	// move them back to a normal tag
+	if (sel->tags & TAG0_MASK)
+		return;
 
 	if ((int32_t)arg->ui == INT_MIN && sel->tags != (~0 & TAGMASK)) {
 		newtags = ~0 & TAGMASK;
 	} else if ((int32_t)arg->ui == INT_MIN && sel->tags == (~0 & TAGMASK)) {
-		newtags = 1 << (sel->mon->pertag->curtag - 1);
+		uint32_t tag = sel->mon->pertag->curtag;
+		if (!tag)
+			tag = get_tags_first_tag_num(sel->mon->tagset[sel->mon->seltags]);
+		if (!tag)
+			tag = 1;
+		newtags = 1u << (tag - 1);
 	} else {
 		newtags = sel->tags ^ (arg->ui & TAGMASK);
 	}
 
 	if (newtags) {
 		sel->tags = newtags;
+		client_reparent_group(sel);
 		focusclient(focustop(selmon), 1);
 		arrange(selmon, false, false);
 	}
@@ -1728,7 +1841,7 @@ static bool view_shift_tag_have_client(const Arg *arg, int dir) {
 	if (!selmon)
 		return false;
 
-	if (selmon->isoverview)
+	if (selmon->isoverview || is_special_active(selmon))
 		return false;
 
 	uint32_t n;
@@ -1885,7 +1998,7 @@ void zoom(const Arg *arg) {
 	Client *c = NULL, *sel = arg->tc ? arg->tc : focustop(selmon);
 
 	if (!sel || !selmon ||
-		!selmon->pertag->ltidxs[selmon->pertag->curtag]->arrange ||
+		!selmon->pertag->ltidxs[get_mon_curtag(selmon)]->arrange ||
 		sel->isfloating)
 		return;
 
@@ -1948,7 +2061,7 @@ void toggleoverview(const Arg *arg) {
 	Client *sel = arg->tc ? arg->tc : selmon->sel;
 
 	selmon->isoverview ^= 1;
-	uint32_t target;
+	uint32_t target = 0;
 	uint32_t visible_client_number = 0;
 
 	if (!selmon->isoverview) {
@@ -1958,11 +2071,11 @@ void toggleoverview(const Arg *arg) {
 	}
 
 	if (selmon->isoverview) {
-		wl_list_for_each(c, &clients, link) if (c && c->mon == selmon &&
-												!client_is_unmanaged(c) &&
-												!client_is_x11_popup(c) &&
-												!c->isminimized &&
-												!c->isunglobal) {
+		wl_list_for_each(c, &clients,
+						 link) if (c && c->mon == selmon &&
+								   !client_is_unmanaged(c) &&
+								   !client_is_x11_popup(c) && !c->isminimized &&
+								   !c->isunglobal && !(c->tags & TAG0_MASK)) {
 			visible_client_number++;
 		}
 		if (visible_client_number > 0) {
@@ -1974,14 +2087,16 @@ void toggleoverview(const Arg *arg) {
 			selmon->ov_tab_layout = 0;
 			return;
 		}
-	} else if (!selmon->isoverview && sel) {
+	} else if (!selmon->isoverview && sel && (sel->tags & TAGMASK) != 0) {
 		target = get_tags_first_tag(sel->tags);
-	} else if (!selmon->isoverview && !sel) {
-		target = (1 << (selmon->pertag->prevtag - 1));
-		view(&(Arg){.ui = target}, false);
-		fix_mon_tagset_from_overview(selmon);
-		refresh_monitors_workspaces_status(selmon);
-		return;
+	} else {
+		target = selmon->ovbk_current_tagset
+					 ? (selmon->ovbk_current_tagset & TAGMASK)
+					 : (selmon->pertag->prevtag
+							? (1 << (selmon->pertag->prevtag - 1))
+							: 1);
+		if (!target)
+			target = 1;
 	}
 
 	if (selmon->isoverview) {
@@ -1996,7 +2111,7 @@ void toggleoverview(const Arg *arg) {
 		wl_list_for_each(c, &clients, link) {
 			if (c && c->mon == selmon && !client_is_unmanaged(c) &&
 				!client_is_x11_popup(c) && !c->isunglobal && !c->isminimized &&
-				client_surface(c)->mapped) {
+				!(c->tags & TAG0_MASK) && client_surface(c)->mapped) {
 				c->animation.overining = true;
 				if (!selmon->is_jump_mode && !selmon->ov_normal_mode)
 					/* tab 布局：先跳过 view 排布，进入后统一重排时再设 */
@@ -2014,7 +2129,8 @@ void toggleoverview(const Arg *arg) {
 		wl_list_for_each(c, &clients, link) {
 			if (c && c->mon == selmon && !c->iskilling &&
 				!client_is_unmanaged(c) && !c->isunglobal && !c->isminimized &&
-				!client_is_x11_popup(c) && client_surface(c)->mapped) {
+				!client_is_x11_popup(c) && client_surface(c)->mapped &&
+				!(c->tags & TAG0_MASK)) {
 				overview_restore(c, &(Arg){.ui = target});
 			}
 		}
@@ -2029,7 +2145,7 @@ void toggleoverview(const Arg *arg) {
 		Client *cc = NULL;
 		wl_list_for_each(cc, &clients, link) {
 			if (cc && cc->mon == selmon && !client_is_unmanaged(cc) &&
-				!client_is_x11_popup(cc))
+				!client_is_x11_popup(cc) && !(cc->tags & TAG0_MASK))
 				cc->animation.overview_enter_anim_set = false;
 		}
 		arrange(selmon, true, false);
@@ -2037,6 +2153,10 @@ void toggleoverview(const Arg *arg) {
 
 	fix_mon_tagset_from_overview(selmon);
 	refresh_monitors_workspaces_status(selmon);
+
+	if (!selmon->isoverview && sel && (sel->tags & target)) {
+		focusclient(sel, 1);
+	}
 
 	return;
 }
@@ -2149,7 +2269,7 @@ void scroller_apply_stack(Client *c, Client *target_client, int32_t direction) {
 		return;
 
 	Monitor *m = c->mon;
-	uint32_t tag = m->pertag->curtag;
+	uint32_t tag = get_client_tag_idx(c);
 
 	bool is_horizontal = (m->pertag->ltidxs[tag]->id == SCROLLER);
 
@@ -2255,12 +2375,13 @@ void toggle_all_floating(const Arg *arg) {
 }
 
 void dwindle_set_split_direction(Client *c, bool istoggle, bool horizontal) {
-	const Layout *layout = c->mon->pertag->ltidxs[c->mon->pertag->curtag];
+	uint32_t tag = get_client_tag_idx(c);
+	const Layout *layout = c->mon->pertag->ltidxs[tag];
 
 	if (layout->id != DWINDLE)
 		return;
 
-	DwindleNode **root = &selmon->pertag->dwindle_root[selmon->pertag->curtag];
+	DwindleNode **root = &c->mon->pertag->dwindle_root[tag];
 	DwindleNode *leaf = dwindle_find_leaf(*root, c);
 
 	if (!leaf)
@@ -2316,11 +2437,12 @@ void dwindle_toggle_current_split(const Arg *arg) {
 	if (!c || !c->mon || c->isfloating)
 		return;
 
-	const Layout *layout = c->mon->pertag->ltidxs[c->mon->pertag->curtag];
+	uint32_t tag = get_client_tag_idx(c);
+	const Layout *layout = c->mon->pertag->ltidxs[tag];
 	if (layout->id != DWINDLE)
 		return;
 
-	DwindleNode *root = c->mon->pertag->dwindle_root[c->mon->pertag->curtag];
+	DwindleNode *root = c->mon->pertag->dwindle_root[tag];
 	DwindleNode *leaf = dwindle_find_leaf(root, c);
 	if (!leaf || !leaf->parent)
 		return;

--- a/src/ext-protocol/ext-workspace.h
+++ b/src/ext-protocol/ext-workspace.h
@@ -177,7 +177,8 @@ void mango_ext_workspace_printstatus(Monitor *m) {
 				}
 			}
 
-			if ((m->tagset[m->seltags] & (1 << (w->tag - 1)) & TAGMASK) ||
+			uint32_t active_tagset = get_monitor_active_tagset(m);
+			if ((active_tagset & (1 << (w->tag - 1)) & TAGMASK) ||
 				m->isoverview) {
 				wlr_ext_workspace_handle_v1_set_hidden(w->ext_workspace, false);
 				wlr_ext_workspace_handle_v1_set_active(w->ext_workspace, true);

--- a/src/input/keyboard.h
+++ b/src/input/keyboard.h
@@ -619,7 +619,7 @@ void keypress(struct wl_listener *listener, void *data) {
 					 toupper((unsigned char)c_char) ==
 						 toupper((unsigned char)c->jump_char))) {
 					focusclient(c, 1);
-					toggleoverview(&(Arg){0});
+					toggleoverview(&(Arg){.tc = c});
 					return;
 				}
 			}

--- a/src/input/pointer.h
+++ b/src/input/pointer.h
@@ -327,7 +327,7 @@ void place_drag_tile_client(Client *c) {
 
 	if (closest && closest->mon) {
 		const Layout *layout =
-			closest->mon->pertag->ltidxs[closest->mon->pertag->curtag];
+			closest->mon->pertag->ltidxs[get_client_tag_idx(closest)];
 
 		if (closest->drop_direction == UNDIR) {
 			setfloating(c, 0);
@@ -345,7 +345,7 @@ void place_drag_tile_client(Client *c) {
 			return;
 		}
 		if (layout->id == DWINDLE) {
-			uint32_t tag = c->mon->pertag->curtag;
+			uint32_t tag = get_client_tag_idx(c);
 			bool insert_before = (closest->drop_direction == LEFT ||
 								  closest->drop_direction == UP);
 			bool split_h = (closest->drop_direction == LEFT ||
@@ -442,6 +442,7 @@ bool handle_buttonpress(struct wlr_pointer_button_event *event) {
 		xytonode(cursor->x, cursor->y, &surface, NULL, NULL, &gb, NULL, NULL);
 		if (toplevel_from_wlr_surface(surface, &c, &l) >= 0) {
 			if (c && c->scene && c->scene->node.enabled &&
+				VISIBLEON(c, c->mon) &&
 				(!client_is_unmanaged(c) || client_wants_focus(c)))
 				focusclient(c, 1);
 
@@ -460,7 +461,7 @@ bool handle_buttonpress(struct wlr_pointer_button_event *event) {
 
 		// overview模式下鼠标左键跳转，右键关闭窗口
 		if (selmon && selmon->isoverview && event->button == BTN_LEFT && c) {
-			toggleoverview(&(Arg){0});
+			toggleoverview(&(Arg){.tc = c});
 			return true;
 		}
 

--- a/src/ipc/ipc.h
+++ b/src/ipc/ipc.h
@@ -106,6 +106,8 @@ static const char *ipc_get_layout_str(void) {
 
 static cJSON *tags_mask_to_array(uint32_t tagmask) {
 	cJSON *arr = cJSON_CreateArray();
+	if (tagmask & TAG0_MASK)
+		cJSON_AddItemToArray(arr, cJSON_CreateNumber(0));
 	for (int i = 0; i < config.tag_num; i++)
 		if (tagmask & (1 << i))
 			cJSON_AddItemToArray(arr, cJSON_CreateNumber(i + 1));
@@ -116,11 +118,12 @@ static cJSON *build_tags_json(Monitor *m) {
 	cJSON *tags_array = cJSON_CreateArray();
 	Client *c = NULL;
 
+	uint32_t active_tagset = get_monitor_active_tagset(m);
 	for (int tag = 1; tag <= config.tag_num; tag++) {
 		int numclients = 0;
 		bool is_active = false, is_urgent = false;
 		uint32_t tagmask = 1 << (tag - 1);
-		if (tagmask & m->tagset[m->seltags])
+		if (tagmask & active_tagset)
 			is_active = true;
 		wl_list_for_each(c, &clients, link) {
 			if (c->mon != m || c->is_logic_hide)
@@ -165,7 +168,7 @@ static cJSON *monitor_active_tags(Monitor *m) {
 		cJSON_AddItemToArray(arr, cJSON_CreateNumber(0));
 		return arr;
 	}
-	tagset = m->tagset[m->seltags];
+	tagset = get_monitor_active_tagset(m);
 	for (int i = 0; i < config.tag_num; i++)
 		if (tagset & (1 << i))
 			cJSON_AddItemToArray(arr, cJSON_CreateNumber(i + 1));
@@ -222,9 +225,9 @@ static cJSON *build_monitor_json(Monitor *m) {
 	cJSON_AddNumberToObject(resp, "height", m->m.height);
 	cJSON_AddNumberToObject(resp, "scale", m->wlr_output->scale);
 	cJSON_AddNumberToObject(resp, "layout_index",
-							m->pertag->ltidxs[m->pertag->curtag] - layouts);
+							m->pertag->ltidxs[get_mon_curtag(m)] - layouts);
 	cJSON_AddStringToObject(resp, "layout_symbol",
-							m->pertag->ltidxs[m->pertag->curtag]->symbol);
+							m->pertag->ltidxs[get_mon_curtag(m)]->symbol);
 	cJSON_AddStringToObject(resp, "last_open_surface", m->last_open_surface);
 	cJSON_AddItemToObject(resp, "tag_num", cJSON_CreateNumber(config.tag_num));
 	cJSON_AddItemToObject(resp, "hide_clients",
@@ -367,7 +370,7 @@ static void handle_command(int client_fd, const char *cmd_raw) {
 		uint32_t tagmask = 1 << tag_idx;
 		int numclients = 0, focused_client = 0;
 		bool is_active = false, is_urgent = false;
-		if (tagmask & m->tagset[m->seltags])
+		if (tagmask & get_monitor_active_tagset(m))
 			is_active = true;
 
 		Client *c, *focused = focustop(m);

--- a/src/layout/arrange.h
+++ b/src/layout/arrange.h
@@ -5,7 +5,8 @@ void set_size_per(Monitor *m, Client *c) {
 	if (!m || !c)
 		return;
 
-	const Layout *current_layout = m->pertag->ltidxs[m->pertag->curtag];
+	uint32_t tag = get_mon_curtag(m);
+	const Layout *current_layout = m->pertag->ltidxs[tag];
 
 	wl_list_for_each(fc, &clients, link) {
 		if (VISIBLEON(fc, m) && ISTILED(fc) && fc != c) {
@@ -21,19 +22,18 @@ void set_size_per(Monitor *m, Client *c) {
 	}
 
 	if (!found || c->isfloating) {
-		c->master_mfact_per = m->pertag->mfacts[m->pertag->curtag];
+		c->master_mfact_per = m->pertag->mfacts[tag];
 		c->master_inner_per = 1.0f;
 		c->stack_inner_per = 1.0f;
 	}
 
 	if (!c->iscustom_scroller_proportion) {
-		c->scroller_proportion =
-			m->pertag->scroller_default_proportion[m->pertag->curtag];
+		c->scroller_proportion = m->pertag->scroller_default_proportion[tag];
 	}
 
 	if (!c->iscustom_scroller_proportion_single) {
 		c->scroller_proportion_single =
-			m->pertag->scroller_default_proportion_single[m->pertag->curtag];
+			m->pertag->scroller_default_proportion_single[tag];
 	}
 }
 
@@ -475,7 +475,7 @@ void resize_tile_grid_fair(Client *grabc, bool isdrag, int32_t offsetx,
 		return;
 
 	// 获取当前布局 ID
-	const Layout *current_layout = m->pertag->ltidxs[m->pertag->curtag];
+	const Layout *current_layout = m->pertag->ltidxs[get_mon_curtag(m)];
 
 	if (!start_drag_window && isdrag) {
 		drag_begin_cursorx = cursor->x;
@@ -768,7 +768,7 @@ void resize_tile_scroller(Client *grabc, bool isdrag, int32_t offsetx,
 		return;
 
 	Monitor *m = grabc->mon;
-	uint32_t tag = m->pertag->curtag;
+	uint32_t tag = get_client_tag_idx(grabc);
 	struct TagScrollerState *st = m->pertag->scroller_state[tag];
 	if (!st)
 		return;
@@ -979,7 +979,7 @@ void resize_tile_client(Client *grabc, bool isdrag, int32_t offsetx,
 		return;
 
 	const Layout *current_layout =
-		grabc->mon->pertag->ltidxs[grabc->mon->pertag->curtag];
+		grabc->mon->pertag->ltidxs[get_client_tag_idx(grabc)];
 	if (current_layout->id == TILE || current_layout->id == DECK ||
 		current_layout->id == CENTER_TILE || current_layout->id == RIGHT_TILE
 
@@ -1025,9 +1025,10 @@ void reset_size_per_mon(Monitor *m, int32_t tile_cilent_num,
 	Client *c = NULL;
 	int32_t i = 0;
 	uint32_t stack_index = 0;
-	uint32_t nmasters = m->pertag->nmasters[m->pertag->curtag];
+	uint32_t tag = get_mon_curtag(m);
+	uint32_t nmasters = m->pertag->nmasters[tag];
 
-	if (m->pertag->ltidxs[m->pertag->curtag]->id != CENTER_TILE) {
+	if (m->pertag->ltidxs[tag]->id != CENTER_TILE) {
 
 		wl_list_for_each(c, &clients, link) {
 			if (VISIBLEON(c, m) && ISFAKETILED(c)) {
@@ -1096,6 +1097,14 @@ void reset_size_per_mon(Monitor *m, int32_t tile_cilent_num,
 	}
 }
 
+// normal-tag client kept visible as background under the special overlay
+static bool special_keep_bg_client(Monitor *m, Client *c) {
+	return is_special_active(m) && !c->is_logic_hide && !c->isminimized &&
+		   ((m->pertag->prevtag > 0 &&
+			 (c->tags & (1 << (m->pertag->prevtag - 1)))) ||
+			(c->tags & (m->tagset[m->seltags ^ 1] & ~TAG0_MASK)));
+}
+
 void pre_calculate_before_arrange(Monitor *m, bool want_animation,
 								  bool from_view, bool only_calculate) {
 	Client *c = NULL;
@@ -1115,10 +1124,10 @@ void pre_calculate_before_arrange(Monitor *m, bool want_animation,
 	m->visible_fake_tiling_clients = 0;
 	m->hide_clients = 0;
 
-	uint32_t tag = m->pertag->curtag;
+	uint32_t tag = get_mon_curtag(m);
 	struct TagScrollerState *st = m->pertag->scroller_state[tag];
 
-	const Layout *cur_layout = m->pertag->ltidxs[m->pertag->curtag];
+	const Layout *cur_layout = m->pertag->ltidxs[tag];
 	if (cur_layout->id == SCROLLER || cur_layout->id == VERTICAL_SCROLLER) {
 		update_scroller_state(m);
 	}
@@ -1176,7 +1185,7 @@ void pre_calculate_before_arrange(Monitor *m, bool want_animation,
 		}
 	}
 
-	nmasters = m->pertag->nmasters[m->pertag->curtag];
+	nmasters = m->pertag->nmasters[get_mon_curtag(m)];
 
 	wl_list_for_each(c, &clients, link) {
 		if (c->iskilling)
@@ -1208,10 +1217,13 @@ void pre_calculate_before_arrange(Monitor *m, bool want_animation,
 
 				if (!only_calculate)
 					set_arrange_visible(m, c, want_animation);
-			} else {
-				/* keep the dragged client visible across view switches */
-				if (!only_calculate && c != grabc)
-					set_arrange_hidden(m, c, want_animation);
+				if (!only_calculate)
+					client_sync_layer(c);
+			} else if (special_keep_bg_client(m, c)) {
+				wlr_scene_node_set_enabled(&c->scene->node, true);
+				c->animation.running = false;
+			} else if (!only_calculate && c != grabc) {
+				set_arrange_hidden(m, c, want_animation);
 			}
 		}
 
@@ -1226,6 +1238,8 @@ void pre_calculate_before_arrange(Monitor *m, bool want_animation,
 		m, m->visible_tiling_clients, total_left_stack_hight_percent,
 		total_right_stack_hight_percent, total_stack_inner_percent,
 		total_master_inner_percent, master_num, stack_num);
+
+	special_update_dim(m);
 }
 
 // remap tags through map; unmapped tags stay as-is.
@@ -1292,7 +1306,8 @@ void tag_gather_apply(Monitor *m) {
 
 	// collect occupied tags on this monitor.
 	wl_list_for_each(c, &clients, link) {
-		if (c->mon == m && !c->iskilling && !c->is_logic_hide)
+		if (c->mon == m && !c->iskilling && !c->is_logic_hide &&
+			!(c->tags & TAG0_MASK))
 			occupied |= c->tags & tagmask;
 	}
 	// the current view counts as occupied even when empty.
@@ -1314,7 +1329,8 @@ void tag_gather_apply(Monitor *m) {
 
 	// remap client tags.
 	wl_list_for_each(c, &clients, link) {
-		if (c->mon != m || c->iskilling || c->is_logic_hide)
+		if (c->mon != m || c->iskilling || c->is_logic_hide ||
+			(c->tags & TAG0_MASK))
 			continue;
 		c->tags = tag_remap_mask(c->tags, map);
 	}
@@ -1345,6 +1361,28 @@ void tag_gather_apply(Monitor *m) {
 		tag_gather_reset_slot(m, i);
 }
 
+// empty special view: keep it when entered via a view switch, exit otherwise.
+// returns true when arrange should stop because the view was closed
+static bool special_handle_empty_view(Monitor *m, bool from_view) {
+	if (!is_special_active(m)) {
+		m->special_empty_view = false;
+		return false;
+	}
+	if (special_has_clients(m)) {
+		m->special_empty_view = false;
+		return false;
+	}
+	if (from_view) {
+		m->special_empty_view = true;
+		return false;
+	}
+	if (!m->special_empty_view) {
+		toggle_special_tag_mon(m);
+		return true;
+	}
+	return false;
+}
+
 void // 17
 arrange(Monitor *m, bool want_animation, bool from_view) {
 
@@ -1358,12 +1396,33 @@ arrange(Monitor *m, bool want_animation, bool from_view) {
 		m->sel = focustop(m);
 	}
 
+	if (special_handle_empty_view(m, from_view))
+		return;
+
 	pre_calculate_before_arrange(m, want_animation, from_view, false);
+
+	bool is_tag0 = is_special_active(m);
+	int32_t saved_oh = m->gappoh, saved_ov = m->gappov;
+	int32_t saved_ih = m->gappih, saved_iv = m->gappiv;
+
+	if (is_tag0) {
+		m->gappoh = m->special_gappoh;
+		m->gappov = m->special_gappov;
+		m->gappih = m->special_gappih;
+		m->gappiv = m->special_gappiv;
+	}
 
 	if (m->isoverview) {
 		overviewlayout.arrange(m);
 	} else {
-		m->pertag->ltidxs[m->pertag->curtag]->arrange(m);
+		m->pertag->ltidxs[get_mon_curtag(m)]->arrange(m);
+	}
+
+	if (is_tag0) {
+		m->gappoh = saved_oh;
+		m->gappov = saved_ov;
+		m->gappih = saved_ih;
+		m->gappiv = saved_iv;
 	}
 
 	// gather after layout/animation setup so tag-switch animations still play.

--- a/src/layout/dwindle.h
+++ b/src/layout/dwindle.h
@@ -336,9 +336,9 @@ static void dwindle_swap_clients(Client *c1, Client *c2) {
 	Monitor *m1 = c1->mon;
 	Monitor *m2 = c2->mon;
 
-	DwindleNode **c1_root = &m1->pertag->dwindle_root[m1->pertag->curtag];
+	DwindleNode **c1_root = &m1->pertag->dwindle_root[get_mon_curtag(m1)];
 	DwindleNode *c1node = dwindle_find_leaf(*c1_root, c1);
-	DwindleNode **c2_root = &m2->pertag->dwindle_root[m2->pertag->curtag];
+	DwindleNode **c2_root = &m2->pertag->dwindle_root[get_mon_curtag(m2)];
 	DwindleNode *c2node = dwindle_find_leaf(*c2_root, c2);
 
 	client_swap_layout_properties(c1, c2);
@@ -357,7 +357,7 @@ static void dwindle_swap_clients(Client *c1, Client *c2) {
 }
 
 static void dwindle_resize_client(Monitor *m, Client *c) {
-	uint32_t tag = m->pertag->curtag;
+	uint32_t tag = get_mon_curtag(m);
 	DwindleNode *leaf = dwindle_find_leaf(m->pertag->dwindle_root[tag], c);
 	if (!leaf)
 		return;
@@ -435,7 +435,7 @@ static void dwindle_resize_client(Monitor *m, Client *c) {
 
 static void dwindle_resize_client_step(Monitor *m, Client *c, int32_t dx,
 									   int32_t dy) {
-	uint32_t tag = m->pertag->curtag;
+	uint32_t tag = get_mon_curtag(m);
 	DwindleNode *leaf = dwindle_find_leaf(m->pertag->dwindle_root[tag], c);
 	if (!leaf)
 		return;
@@ -485,7 +485,7 @@ static void dwindle_resize_client_step(Monitor *m, Client *c, int32_t dx,
 static void dwindle_remove_client(Client *c) {
 	Monitor *m;
 	wl_list_for_each(m, &mons, link) {
-		for (uint32_t t = 0; t < (uint32_t)config.tag_num + 1; t++)
+		for (uint32_t t = 0; t < PERTAG_SLOTS; t++)
 			dwindle_remove(&m->pertag->dwindle_root[t], c);
 	}
 }
@@ -586,7 +586,7 @@ void dwindle(Monitor *m) {
 	if (n == 0)
 		return;
 
-	uint32_t tag = m->pertag->curtag;
+	uint32_t tag = get_mon_curtag(m);
 	DwindleNode **root = &m->pertag->dwindle_root[tag];
 	float ratio = config.dwindle_split_ratio;
 
@@ -675,6 +675,6 @@ void dwindle(Monitor *m) {
 }
 
 void cleanup_monitor_dwindle(Monitor *m) {
-	for (uint32_t t = 0; t < (uint32_t)config.tag_num + 1; t++)
+	for (uint32_t t = 0; t < PERTAG_SLOTS; t++)
 		dwindle_free_tree(m->pertag->dwindle_root[t]);
 }

--- a/src/layout/horizontal.h
+++ b/src/layout/horizontal.h
@@ -7,7 +7,7 @@ void tile(Monitor *m) {
 	int32_t stack_num = 0;
 
 	n = m->visible_fake_tiling_clients;
-	master_num = m->pertag->nmasters[m->pertag->curtag];
+	master_num = m->pertag->nmasters[get_mon_curtag(m)];
 	master_num = n > master_num ? master_num : n;
 	stack_num = n - master_num;
 
@@ -38,10 +38,10 @@ void tile(Monitor *m) {
 	}
 
 	mfact = fc->master_mfact_per > 0.0f ? fc->master_mfact_per
-										: m->pertag->mfacts[m->pertag->curtag];
+										: m->pertag->mfacts[get_mon_curtag(m)];
 
-	if (n > m->pertag->nmasters[m->pertag->curtag])
-		mw = m->pertag->nmasters[m->pertag->curtag]
+	if (n > m->pertag->nmasters[get_mon_curtag(m)])
+		mw = m->pertag->nmasters[get_mon_curtag(m)]
 				 ? (m->w.width + cur_gappih * ie) * mfact
 				 : 0;
 	else
@@ -61,8 +61,8 @@ void tile(Monitor *m) {
 	wl_list_for_each(c, &clients, link) {
 		if (!VISIBLEON(c, m) || !ISFAKETILED(c))
 			continue;
-		if (i < m->pertag->nmasters[m->pertag->curtag]) {
-			r = MANGO_MIN(n, m->pertag->nmasters[m->pertag->curtag]) - i;
+		if (i < m->pertag->nmasters[get_mon_curtag(m)]) {
+			r = MANGO_MIN(n, m->pertag->nmasters[get_mon_curtag(m)]) - i;
 			if (c->master_inner_per > 0.0f) {
 				h = master_surplus_height * c->master_inner_per /
 					master_surplus_ratio;
@@ -124,7 +124,7 @@ void right_tile(Monitor *m) {
 	int32_t stack_num = 0;
 
 	n = m->visible_fake_tiling_clients;
-	master_num = m->pertag->nmasters[m->pertag->curtag];
+	master_num = m->pertag->nmasters[get_mon_curtag(m)];
 	master_num = n > master_num ? master_num : n;
 	stack_num = n - master_num;
 
@@ -155,10 +155,10 @@ void right_tile(Monitor *m) {
 	}
 
 	mfact = fc->master_mfact_per > 0.0f ? fc->master_mfact_per
-										: m->pertag->mfacts[m->pertag->curtag];
+										: m->pertag->mfacts[get_mon_curtag(m)];
 
-	if (n > m->pertag->nmasters[m->pertag->curtag])
-		mw = m->pertag->nmasters[m->pertag->curtag]
+	if (n > m->pertag->nmasters[get_mon_curtag(m)])
+		mw = m->pertag->nmasters[get_mon_curtag(m)]
 				 ? (m->w.width + cur_gappih * ie) * mfact
 				 : 0;
 	else
@@ -178,8 +178,8 @@ void right_tile(Monitor *m) {
 	wl_list_for_each(c, &clients, link) {
 		if (!VISIBLEON(c, m) || !ISFAKETILED(c))
 			continue;
-		if (i < m->pertag->nmasters[m->pertag->curtag]) {
-			r = MANGO_MIN(n, m->pertag->nmasters[m->pertag->curtag]) - i;
+		if (i < m->pertag->nmasters[get_mon_curtag(m)]) {
+			r = MANGO_MIN(n, m->pertag->nmasters[get_mon_curtag(m)]) - i;
 			if (c->master_inner_per > 0.0f) {
 				h = master_surplus_height * c->master_inner_per /
 					master_surplus_ratio;
@@ -243,7 +243,7 @@ void center_tile(Monitor *m) {
 	int32_t stack_num = 0;
 
 	n = m->visible_fake_tiling_clients;
-	master_num = m->pertag->nmasters[m->pertag->curtag];
+	master_num = m->pertag->nmasters[get_mon_curtag(m)];
 	master_num = n > master_num ? master_num : n;
 	stack_num = n - master_num;
 
@@ -276,9 +276,9 @@ void center_tile(Monitor *m) {
 					 ? 0
 					 : cur_gappoh;
 
-	int32_t nmasters = m->pertag->nmasters[m->pertag->curtag];
+	int32_t nmasters = m->pertag->nmasters[get_mon_curtag(m)];
 	mfact = fc->master_mfact_per > 0.0f ? fc->master_mfact_per
-										: m->pertag->mfacts[m->pertag->curtag];
+										: m->pertag->mfacts[get_mon_curtag(m)];
 
 	// 初始化区域
 	mw = m->w.width;
@@ -517,7 +517,7 @@ void deck(Monitor *m) {
 	Client *c = NULL;
 	Client *fc = NULL;
 	float mfact;
-	uint32_t nmasters = m->pertag->nmasters[m->pertag->curtag];
+	uint32_t nmasters = m->pertag->nmasters[get_mon_curtag(m)];
 
 	int32_t cur_gappih = enablegaps ? m->gappih : 0;
 	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;
@@ -544,7 +544,7 @@ void deck(Monitor *m) {
 	}
 
 	mfact = fc->master_mfact_per > 0.0f ? fc->master_mfact_per
-										: m->pertag->mfacts[m->pertag->curtag];
+										: m->pertag->mfacts[get_mon_curtag(m)];
 
 	if (n > nmasters)
 		mw = nmasters ? round((m->w.width - 2 * cur_gappoh) * mfact) : 0;

--- a/src/layout/overview.h
+++ b/src/layout/overview.h
@@ -481,7 +481,7 @@ void finish_jump_mode(Monitor *m) {
 
 	Client *c;
 	wl_list_for_each(c, &clients, link) {
-		if (VISIBLEON(c, m)) {
+		if (c->mon == m) {
 			if (c->jump_label_node &&
 				c->jump_label_node->scene_buffer->node.enabled) {
 				c->jump_char = '\0';

--- a/src/layout/scroll.h
+++ b/src/layout/scroll.h
@@ -77,7 +77,7 @@ static void clear_scroller_state(struct TagScrollerState *st) {
 
 /* 在 Monitor 销毁时清理所有 tag 的 scroller 状态 */
 static void cleanup_monitor_scroller(Monitor *m) {
-	for (int t = 0; t < config.tag_num + 1; t++) {
+	for (int t = 0; t < PERTAG_SLOTS; t++) {
 		if (m->pertag->scroller_state[t]) {
 			clear_scroller_state(m->pertag->scroller_state[t]);
 			m->pertag->scroller_state[t] = NULL;
@@ -284,7 +284,7 @@ void arrange_stack_vertical_node(struct ScrollerStackNode *head,
 }
 
 void scroller(Monitor *m) {
-	uint32_t tag = m->pertag->curtag;
+	uint32_t tag = get_mon_curtag(m);
 	struct TagScrollerState *st = ensure_scroller_state(m, tag);
 	Client *c = NULL;
 	float scroller_default_proportion_single =
@@ -527,7 +527,7 @@ void scroller(Monitor *m) {
 }
 
 void vertical_scroller(Monitor *m) {
-	uint32_t tag = m->pertag->curtag;
+	uint32_t tag = get_mon_curtag(m);
 	int32_t bar_height = 0;
 	struct TagScrollerState *st = ensure_scroller_state(m, tag);
 	Client *c = NULL;
@@ -781,7 +781,7 @@ void vertical_scroller(Monitor *m) {
 void scroller_remove_client(Client *c) {
 	Monitor *m;
 	wl_list_for_each(m, &mons, link) {
-		for (uint32_t t = 0; t < (uint32_t)config.tag_num + 1; t++) {
+		for (uint32_t t = 0; t < PERTAG_SLOTS; t++) {
 			struct TagScrollerState *st = m->pertag->scroller_state[t];
 			if (!st)
 				continue;
@@ -804,7 +804,7 @@ void scroller_insert_stack(Client *c, Client *target_client,
 		setmaximizescreen(c, 0, true);
 
 	Monitor *m = c->mon;
-	uint32_t tag = m->pertag->curtag;
+	uint32_t tag = get_mon_curtag(m);
 	struct TagScrollerState *st = ensure_scroller_state(m, tag);
 
 	struct ScrollerStackNode *cnode = find_scroller_node(st, c);
@@ -902,7 +902,7 @@ void scroller_drop_tile(Client *c, Client *closest, int vertical) {
 Client *scroll_get_stack_head_client(Client *c) {
 	if (!c || !c->mon)
 		return c;
-	uint32_t tag = c->mon->pertag->curtag;
+	uint32_t tag = get_client_tag_idx(c);
 	struct TagScrollerState *st = c->mon->pertag->scroller_state[tag];
 	if (st) {
 		struct ScrollerStackNode *n = find_scroller_node(st, c);
@@ -918,7 +918,7 @@ Client *scroll_get_stack_head_client(Client *c) {
 Client *scroll_get_stack_tail_client(Client *c) {
 	if (!c || !c->mon)
 		return c;
-	uint32_t tag = c->mon->pertag->curtag;
+	uint32_t tag = get_client_tag_idx(c);
 	struct TagScrollerState *st = c->mon->pertag->scroller_state[tag];
 	if (st) {
 		struct ScrollerStackNode *n = find_scroller_node(st, c);
@@ -932,7 +932,7 @@ Client *scroll_get_stack_tail_client(Client *c) {
 }
 
 static void update_scroller_state(Monitor *m) {
-	uint32_t tag = m->pertag->curtag;
+	uint32_t tag = get_mon_curtag(m);
 	struct TagScrollerState *st = ensure_scroller_state(m, tag);
 
 	/* 收集当前可见的所有 scroller 平铺窗口 */
@@ -1073,8 +1073,8 @@ void exchange_two_scroller_clients(Client *c1, Client *c2) {
 	struct ScrollerStackNode *n2 = NULL;
 	Monitor *m1 = c1->mon;
 	Monitor *m2 = c2->mon;
-	uint32_t tag1 = m1->pertag->curtag;
-	uint32_t tag2 = m2->pertag->curtag;
+	uint32_t tag1 = get_mon_curtag(m1);
+	uint32_t tag2 = get_mon_curtag(m2);
 
 	struct TagScrollerState *st1 = ensure_scroller_state(m1, tag1);
 	n1 = find_scroller_node(st1, c1);

--- a/src/layout/vertical.h
+++ b/src/layout/vertical.h
@@ -7,7 +7,7 @@ void vertical_tile(Monitor *m) {
 	int32_t stack_num = 0;
 
 	n = m->visible_fake_tiling_clients;
-	master_num = m->pertag->nmasters[m->pertag->curtag];
+	master_num = m->pertag->nmasters[get_mon_curtag(m)];
 	master_num = n > master_num ? master_num : n;
 	stack_num = n - master_num;
 
@@ -34,10 +34,10 @@ void vertical_tile(Monitor *m) {
 	}
 
 	mfact = fc->master_mfact_per > 0.0f ? fc->master_mfact_per
-										: m->pertag->mfacts[m->pertag->curtag];
+										: m->pertag->mfacts[get_mon_curtag(m)];
 
-	if (n > m->pertag->nmasters[m->pertag->curtag])
-		mh = m->pertag->nmasters[m->pertag->curtag]
+	if (n > m->pertag->nmasters[get_mon_curtag(m)])
+		mh = m->pertag->nmasters[get_mon_curtag(m)]
 				 ? (m->w.height + cur_gapiv * ie) * mfact
 				 : 0;
 	else
@@ -57,8 +57,8 @@ void vertical_tile(Monitor *m) {
 	wl_list_for_each(c, &clients, link) {
 		if (!VISIBLEON(c, m) || !ISFAKETILED(c))
 			continue;
-		if (i < m->pertag->nmasters[m->pertag->curtag]) {
-			r = MANGO_MIN(n, m->pertag->nmasters[m->pertag->curtag]) - i;
+		if (i < m->pertag->nmasters[get_mon_curtag(m)]) {
+			r = MANGO_MIN(n, m->pertag->nmasters[get_mon_curtag(m)]) - i;
 			if (c->master_inner_per > 0.0f) {
 				w = master_surplus_width * c->master_inner_per /
 					master_surplus_ratio;
@@ -115,7 +115,7 @@ void vertical_deck(Monitor *m) {
 	Client *c = NULL;
 	Client *fc = NULL;
 	float mfact;
-	uint32_t nmasters = m->pertag->nmasters[m->pertag->curtag];
+	uint32_t nmasters = m->pertag->nmasters[get_mon_curtag(m)];
 
 	int32_t cur_gappiv = enablegaps ? m->gappiv : 0;
 	int32_t cur_gappoh = enablegaps ? m->gappoh : 0;
@@ -142,7 +142,7 @@ void vertical_deck(Monitor *m) {
 	}
 
 	mfact = fc->master_mfact_per > 0.0f ? fc->master_mfact_per
-										: m->pertag->mfacts[m->pertag->curtag];
+										: m->pertag->mfacts[get_mon_curtag(m)];
 
 	if (n > nmasters)
 		mh = nmasters ? round((m->w.height - 2 * cur_gappov) * mfact) : 0;

--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -684,7 +684,7 @@ bool check_hit_no_border(Client *c) {
 	}
 
 	if (c->mon && !c->mon->isoverview &&
-		c->mon->pertag->no_render_border[get_tags_first_tag_num(c->tags)]) {
+		c->mon->pertag->no_render_border[get_client_tag_idx(c)]) {
 		hit_no_border = true;
 	}
 
@@ -869,7 +869,7 @@ Client *find_client_by_direction(Client *tc, const Arg *arg,
 				continue;
 			if (!config.focus_cross_monitor && c->mon != tc->mon)
 				continue;
-			if (!(c->tags & c->mon->tagset[c->mon->seltags]))
+			if (!(c->tags & c->mon->tagset[c->mon->seltags]) && !c->isglobal)
 				continue;
 
 			int32_t c_l = c->geom.x;
@@ -1050,6 +1050,8 @@ float *get_border_color(Client *c) {
 int32_t is_single_bit_set(uint32_t x) { return x && !(x & (x - 1)); }
 
 bool client_only_in_one_tag(Client *c) {
+	if (c && (c->tags & TAG0_MASK))
+		return true;
 	uint32_t masked = c->tags & TAGMASK;
 	if (is_single_bit_set(masked)) {
 		return true;
@@ -1062,7 +1064,7 @@ bool client_is_in_same_stack(Client *sc, Client *tc, Client *fc) {
 	if (!sc || !tc || !sc->mon)
 		return false;
 
-	uint32_t id = sc->mon->pertag->ltidxs[sc->mon->pertag->curtag]->id;
+	uint32_t id = sc->mon->pertag->ltidxs[get_client_tag_idx(sc)]->id;
 
 	if ((id != SCROLLER && id != VERTICAL_SCROLLER) && tc->mon != selmon &&
 		(tc->isfullscreen || tc->ismaximizescreen))
@@ -1229,7 +1231,8 @@ void client_reset_mon_tags(Client *c, Monitor *mon, uint32_t newtags) {
 	} else if (!newtags && mon && mon->isoverview) {
 		c->tags = mon->ovbk_current_tagset;
 	} else if (newtags) {
-		uint32_t masked = newtags & TAGMASK;
+		uint32_t masked =
+			(newtags & TAG0_MASK) ? TAG0_MASK : (newtags & TAGMASK);
 		c->tags = masked ? masked : mon->tagset[mon->seltags];
 	} else {
 		c->tags = mon->tagset[mon->seltags];
@@ -1280,7 +1283,7 @@ void applyrules(Client *c) {
 		apply_rule_properties(c, r);
 
 		// // set tags
-		if (r->tags > 0) {
+		if (r->tags) {
 			newtags |= r->tags;
 		} else if (parent) {
 			newtags = parent->tags;
@@ -1334,6 +1337,12 @@ void applyrules(Client *c) {
 		}
 	}
 
+	if (newtags == 0 && parent && (parent->tags & TAG0_MASK)) {
+		newtags = TAG0_MASK;
+	} else if (newtags == 0 && is_special_active(mon)) {
+		newtags = TAG0_MASK;
+	}
+
 	if (mon)
 		set_size_per(mon, c);
 
@@ -1378,13 +1387,14 @@ void applyrules(Client *c) {
 	bool should_init_get_focus =
 		!c->isopensilent &&
 		!(client_is_x11_popup(c) && client_should_ignore_focus(c)) && mon &&
-		(!c->istagsilent || !newtags || newtags & mon->tagset[mon->seltags]);
+		(!c->istagsilent || !newtags || (newtags & mon->tagset[mon->seltags]));
 
 	if (!should_init_get_focus) {
 		wl_list_safe_reinsert_prev(&fstack, &c->flink);
 	}
 
 	setmon(c, mon, newtags, should_init_get_focus);
+	client_reparent_group(c);
 
 	if (!c->isfloating) {
 		c->old_stack_inner_per = c->stack_inner_per;
@@ -2028,7 +2038,7 @@ void unmapnotify(struct wl_listener *listener, void *data) {
 	switcher_remove_client(c);
 	struct ScrollerStackNode *target_node =
 		c->mon ? find_scroller_node(
-					 c->mon->pertag->scroller_state[c->mon->pertag->curtag], c)
+					 c->mon->pertag->scroller_state[get_client_tag_idx(c)], c)
 			   : NULL;
 	struct ScrollerStackNode *prev_node =
 		target_node ? target_node->prev_in_stack : NULL;
@@ -2086,6 +2096,10 @@ void unmapnotify(struct wl_listener *listener, void *data) {
 		} else if (prev_node && !c->swallowing) {
 			nextfocus = prev_node->client;
 		} else {
+			nextfocus = focustop(selmon);
+		}
+
+		if (nextfocus && !VISIBLEON(nextfocus, selmon)) {
 			nextfocus = focustop(selmon);
 		}
 
@@ -2405,9 +2419,8 @@ void focusclient(Client *c, int32_t lift) {
 		wl_list_remove(&c->flink);
 		wl_list_insert(&fstack, &c->flink);
 
-		if (c && selmon->prevsel &&
-			(selmon->prevsel->tags & selmon->tagset[selmon->seltags]) &&
-			(c->tags & selmon->tagset[selmon->seltags]) && !c->isfloating &&
+		if (c && selmon->prevsel && TAGMATCH(selmon->prevsel, selmon) &&
+			TAGMATCH(c, selmon) && !c->isfloating &&
 			(is_scroller_layout(selmon) || is_monocle_layout(selmon))) {
 			arrange(selmon, false, false);
 		}
@@ -2465,8 +2478,11 @@ void focusclient(Client *c, int32_t lift) {
 
 		if (selmon && selmon->sel &&
 			(!VISIBLEON(selmon->sel, selmon) || selmon->sel->iskilling ||
-			 !client_surface(selmon->sel)->mapped))
+			 !client_surface(selmon->sel)->mapped)) {
+			selmon->sel->isfocusing = false;
+			client_set_unfocused_opacity_animation(selmon->sel);
 			selmon->sel = NULL;
+		}
 
 		// clear text input focus state
 		mango_im_relay_set_focus(mango_input_method_relay, NULL);
@@ -2554,17 +2570,19 @@ void view_in_mon(const Arg *arg, bool want_animation, Monitor *m,
 		}
 	}
 
-	if ((m->tagset[m->seltags] & arg->ui & TAGMASK) != 0) {
+	if ((m->tagset[m->seltags] & arg->ui & (TAGMASK | TAG0_MASK)) != 0) {
 		want_animation = false;
 	}
 
 	m->seltags ^= 1; /* toggle sel tagset */
 
-	if (arg->ui & TAGMASK) {
-		m->tagset[m->seltags] = arg->ui & TAGMASK;
+	if (arg->ui & (TAGMASK | TAG0_MASK)) {
+		m->tagset[m->seltags] = arg->ui & (TAGMASK | TAG0_MASK);
 		tmptag = m->pertag->curtag;
 
-		if (arg->ui == (~0 & TAGMASK))
+		if (arg->ui & TAG0_MASK)
+			m->pertag->curtag = 0;
+		else if (arg->ui == (~0 & TAGMASK))
 			m->pertag->curtag = 0;
 		else {
 			for (i = 0; !(arg->ui & 1 << i) && i < (uint32_t)config.tag_num &&
@@ -2609,15 +2627,20 @@ void view(const Arg *arg, bool want_animation) {
 
 void tag_client(const Arg *arg, Client *target_client) {
 	Client *fc = NULL;
-	if (target_client && arg->ui & TAGMASK) {
+	if (target_client && (arg->ui & (TAGMASK | TAG0_MASK))) {
 
-		target_client->tags = arg->ui & TAGMASK;
+		target_client->tags =
+			(arg->ui & TAG0_MASK) ? TAG0_MASK : (arg->ui & TAGMASK);
+		client_reparent_group(target_client);
 
 		wl_list_for_each(fc, &clients, link) {
 			if (fc && fc != target_client && target_client->tags & fc->tags &&
 				ISFULLSCREEN(fc) && !target_client->isfloating) {
 				clear_fullscreen_flag(fc);
 			}
+		}
+		if (arg->ui & TAG0_MASK) {
+			arrange(target_client->mon, false, false);
 		}
 		view(&(Arg){.ui = arg->ui, .i = arg->i}, true);
 
@@ -2639,7 +2662,7 @@ void show_hide_client(Client *c) {
 	if (!c->is_in_scratchpad) {
 		tag_client(&(Arg){.ui = target}, c);
 	} else {
-		c->tags = c->oldtags;
+		c->tags = c->mini_restore_tag ? c->mini_restore_tag : c->oldtags;
 		c->isminimized = 0;
 		if (c->mon)
 			arrange(c->mon, false, false);
@@ -2960,12 +2983,15 @@ void set_minimized(Client *c) {
 		return;
 
 	c->isglobal = 0;
+
 	c->oldtags = c->mon->tagset[c->mon->seltags];
 	c->mini_restore_tag = c->tags;
 	c->tags = 0;
 	client_pending_minimized_state(c, 1);
 	c->is_in_scratchpad = 1;
 	c->is_scratchpad_show = 0;
+	client_reparent_group(c);
+
 	focusclient(focustop(selmon), 1);
 	arrange(c->mon, false, false);
 
@@ -2983,6 +3009,7 @@ void unminimize(Client *c) {
 		c->is_scratchpad_show = 0;
 		c->is_in_scratchpad = 0;
 		c->isnamedscratchpad = 0;
+		client_reparent_group(c);
 		setborder_color(c);
 		return;
 	}
@@ -2992,6 +3019,7 @@ void unminimize(Client *c) {
 		c->is_scratchpad_show = 0;
 		c->is_in_scratchpad = 0;
 		c->isnamedscratchpad = 0;
+		client_reparent_group(c);
 		setborder_color(c);
 		arrange(c->mon, false, false);
 		return;
@@ -3002,7 +3030,7 @@ void exit_scroller_stack(Client *c) {
 	if (!c || !c->mon)
 		return;
 
-	uint32_t tag = c->mon->pertag->curtag;
+	uint32_t tag = get_client_tag_idx(c);
 	struct TagScrollerState *st = c->mon->pertag->scroller_state[tag];
 	if (st) {
 		struct ScrollerStackNode *n = find_scroller_node(st, c);
@@ -3025,9 +3053,8 @@ void clear_fullscreen_and_maximized_state(Monitor *m) {
 /*清除全屏标志,还原全屏时清0的border*/
 void clear_fullscreen_flag(Client *c) {
 
-	if ((c->mon->pertag->ltidxs[get_tags_first_tag_num(c->tags)]->id ==
-			 SCROLLER ||
-		 c->mon->pertag->ltidxs[get_tags_first_tag_num(c->tags)]->id ==
+	if ((c->mon->pertag->ltidxs[get_client_tag_idx(c)]->id == SCROLLER ||
+		 c->mon->pertag->ltidxs[get_client_tag_idx(c)]->id ==
 			 VERTICAL_SCROLLER) &&
 		!c->isfloating) {
 		return;
@@ -3088,6 +3115,7 @@ void show_scratchpad(Client *c) {
 		resize(c, c->geom, 0);
 	}
 
+	client_reparent_group(c);
 	c->oldtags = c->mon->tagset[c->mon->seltags];
 	wl_list_safe_reinsert_next(&clients, &c->link);
 	show_hide_client(c);
@@ -3128,18 +3156,22 @@ bool switch_scratchpad_client_state(Client *c) {
 		}
 	}
 
+	// visible on this tag -> hide
 	if (c->is_in_scratchpad && c->is_scratchpad_show && c->mon &&
-		(c->mon->tagset[c->mon->seltags] & c->tags) == 0) {
-		c->tags = c->mon->tagset[c->mon->seltags];
-		arrange(c->mon, false, false);
-		focusclient(c, 1);
-		return true;
-	} else if (c->is_in_scratchpad && c->is_scratchpad_show &&
-			   (c->mon->tagset[c->mon->seltags] & c->tags) != 0) {
+		(c->mon->tagset[c->mon->seltags] & c->tags)) {
 		set_minimized(c);
 		return true;
-	} else if (c && c->is_in_scratchpad && !c->is_scratchpad_show) {
-		show_scratchpad(c);
+	} else if (c->is_in_scratchpad && c->mon) {
+		// not visible on this tag: move the scratchpad here and show it
+		c->tags = c->mon->tagset[c->mon->seltags];
+		c->oldtags = c->tags;
+		c->mini_restore_tag = c->tags;
+		if (c->is_scratchpad_show) {
+			arrange(c->mon, false, false);
+			focusclient(c, 1);
+		} else {
+			show_scratchpad(c);
+		}
 		return true;
 	}
 
@@ -3185,8 +3217,8 @@ void exchange_two_client(Client *c1, Client *c2) {
 
 	Monitor *m1 = c1->mon;
 	Monitor *m2 = c2->mon;
-	const Layout *layout1 = m1->pertag->ltidxs[m1->pertag->curtag];
-	const Layout *layout2 = m2->pertag->ltidxs[m2->pertag->curtag];
+	const Layout *layout1 = m1->pertag->ltidxs[get_client_tag_idx(c1)];
+	const Layout *layout2 = m2->pertag->ltidxs[get_client_tag_idx(c2)];
 
 	if (layout1->id == SCROLLER || layout2->id == SCROLLER ||
 		layout1->id == VERTICAL_SCROLLER || layout2->id == VERTICAL_SCROLLER) {
@@ -3288,12 +3320,12 @@ void client_replace(Client *c, Client *w, bool is_group_change_member,
 	if (!w->mon)
 		return;
 
-	const Layout *layout = w->mon->pertag->ltidxs[w->mon->pertag->curtag];
+	const Layout *layout = w->mon->pertag->ltidxs[get_client_tag_idx(w)];
 
 	if (layout->id == DWINDLE || layout->id == SCROLLER ||
 		layout->id == VERTICAL_SCROLLER) {
 
-		for (uint32_t t = 0; t < (uint32_t)config.tag_num + 1; t++) {
+		for (uint32_t t = 0; t < PERTAG_SLOTS; t++) {
 			/* dwindle */
 
 			if (layout->id == DWINDLE) {
@@ -3323,7 +3355,7 @@ void client_replace(Client *c, Client *w, bool is_group_change_member,
 
 	/* 同步当前活动 tag 的全局客户端字段 */
 	if (layout->id == SCROLLER || layout->id == VERTICAL_SCROLLER) {
-		sync_scroller_state_to_clients(w->mon, w->mon->pertag->curtag);
+		sync_scroller_state_to_clients(w->mon, get_client_tag_idx(w));
 	}
 }
 
@@ -3444,16 +3476,41 @@ void client_add_jump_label_node(Client *c) {
 	wlr_scene_node_set_enabled(&c->jump_label_node->scene_buffer->node, false);
 }
 
+// scene layer a client belongs to; shown scratchpads join the special
+// layers while the special workspace is active
+uint32_t client_target_layer(Client *c) {
+	if (c->isoverlay)
+		return LyrOverlay;
+
+	bool special_overlay = (c->tags & TAG0_MASK) ||
+						   (is_special_active(c->mon) && c->is_in_scratchpad &&
+							c->is_scratchpad_show && !c->isminimized);
+
+	if (special_overlay)
+		return c->isfloating || c->isfullscreen ? LyrSpecialTop
+			   : c->ismaximizescreen			? LyrSpecialMaximize
+												: LyrSpecialTile;
+
+	return c->isfloating || c->isfullscreen ? LyrTop
+		   : c->ismaximizescreen			? LyrMaximize
+											: LyrTile;
+}
+
+// sync client scene to its target layer
+void client_sync_layer(Client *c) {
+	if (!c || !c->scene || !c->mon)
+		return;
+	if (c->scene->node.parent != layers[client_target_layer(c)])
+		client_reparent_group(c);
+}
+
 void client_add_group_bar(Client *c) {
 
 	if (config.group_bar_height <= 0) {
 		return;
 	}
 
-	uint32_t layer = c->isoverlay						? LyrOverlay
-					 : c->isfloating || c->isfullscreen ? LyrTop
-					 : c->ismaximizescreen				? LyrMaximize
-														: LyrTile;
+	uint32_t layer = client_target_layer(c);
 
 	c->group_bar = mango_group_bar_create(c, GroupBar, layers[layer],
 										  config.groupbardata, 0, 0);
@@ -3552,10 +3609,7 @@ void client_reparent_group(Client *c) {
 	if (!c || !c->mon)
 		return;
 
-	int32_t layer = c->isoverlay					   ? LyrOverlay
-					: c->isfloating || c->isfullscreen ? LyrTop
-					: c->ismaximizescreen			   ? LyrMaximize
-													   : LyrTile;
+	int32_t layer = client_target_layer(c);
 
 	Client *head = c;
 	while (head->group_prev)

--- a/src/manage/layer.h
+++ b/src/manage/layer.h
@@ -213,6 +213,7 @@ void maplayersurfacenotify(struct wl_listener *listener, void *data) {
 		l->animainit_geom = l->animation.current = l->current = l->pending =
 			l->geom;
 	}
+
 	// 刷新布局，让窗口能感应到exclude_zone变化以及设置独占表面
 	arrangelayers(l->mon);
 	reset_exclusive_layers_focus(l->mon);

--- a/src/manage/misc.h
+++ b/src/manage/misc.h
@@ -126,6 +126,16 @@ void xytonode(double x, double y, struct wlr_surface **psurface, Client **pc,
 		if (!node)
 			continue;
 
+		Monitor *cm = xytomon(x, y);
+		if (cm && cm->special_dim_rect && cm->special_dim_rect->node.enabled &&
+			node == &cm->special_dim_rect->node) {
+			c = NULL;
+			l = NULL;
+			surface = NULL;
+			mangogroupbar = NULL;
+			break;
+		}
+
 		if (node->type == WLR_SCENE_NODE_BUFFER) {
 			struct wlr_scene_surface *scene_surface =
 				wlr_scene_surface_try_from_buffer(

--- a/src/manage/monitor.h
+++ b/src/manage/monitor.h
@@ -17,10 +17,10 @@ Monitor *dirtomon(enum wlr_direction dir) {
 
 bool is_scroller_layout(Monitor *m) {
 
-	if (m->pertag->ltidxs[m->pertag->curtag]->id == SCROLLER)
+	if (m->pertag->ltidxs[get_mon_curtag(m)]->id == SCROLLER)
 		return true;
 
-	if (m->pertag->ltidxs[m->pertag->curtag]->id == VERTICAL_SCROLLER)
+	if (m->pertag->ltidxs[get_mon_curtag(m)]->id == VERTICAL_SCROLLER)
 		return true;
 
 	return false;
@@ -28,7 +28,7 @@ bool is_scroller_layout(Monitor *m) {
 
 bool is_monocle_layout(Monitor *m) {
 
-	if (m->pertag->ltidxs[m->pertag->curtag]->id == MONOCLE)
+	if (m->pertag->ltidxs[get_mon_curtag(m)]->id == MONOCLE)
 		return true;
 
 	return false;
@@ -36,10 +36,26 @@ bool is_monocle_layout(Monitor *m) {
 
 bool is_centertile_layout(Monitor *m) {
 
-	if (m->pertag->ltidxs[m->pertag->curtag]->id == CENTER_TILE)
+	if (m->pertag->ltidxs[get_mon_curtag(m)]->id == CENTER_TILE)
 		return true;
 
 	return false;
+}
+
+// sync the special overlay dim layer to the monitor and view state
+void special_update_dim(Monitor *m) {
+	if (!m || !m->special_dim_rect)
+		return;
+	wlr_scene_rect_set_size(m->special_dim_rect, m->m.width, m->m.height);
+	wlr_scene_node_set_position(&m->special_dim_rect->node, m->m.x, m->m.y);
+	if (is_special_active(m)) {
+		wlr_scene_rect_set_color(
+			m->special_dim_rect,
+			(float[4]){0.0f, 0.0f, 0.0f, config.special_dim});
+		wlr_scene_node_set_enabled(&m->special_dim_rect->node, true);
+	} else {
+		wlr_scene_node_set_enabled(&m->special_dim_rect->node, false);
+	}
 }
 
 uint32_t get_tag_status(uint32_t tag, Monitor *m) {
@@ -66,6 +82,10 @@ uint32_t get_tags_first_tag_num(uint32_t source_tags) {
 		return 0;
 	}
 
+	if (source_tags & TAG0_MASK) {
+		return 0;
+	}
+
 	for (i = 0; !(tag & 1) && source_tags != 0 && i < (uint32_t)config.tag_num;
 		 i++) {
 		tag = source_tags >> i;
@@ -86,7 +106,16 @@ uint32_t get_tags_first_tag(uint32_t source_tags) {
 	tag = 0;
 
 	if (!source_tags) {
-		return selmon->pertag->curtag;
+		return is_special_active(selmon)
+				   ? TAG0_MASK
+				   : (selmon ? (1 << (selmon->pertag->curtag
+										  ? selmon->pertag->curtag - 1
+										  : 0))
+							 : 1);
+	}
+
+	if (source_tags & TAG0_MASK) {
+		return TAG0_MASK;
 	}
 
 	for (i = 0; !(tag & 1) && source_tags != 0 && i < (uint32_t)config.tag_num;
@@ -476,6 +505,10 @@ void createmon(struct wl_listener *listener, void *data) {
 	m->gappiv = config.gappiv;
 	m->gappoh = config.gappoh;
 	m->gappov = config.gappov;
+	m->special_gappih = config.special_gappih;
+	m->special_gappiv = config.special_gappiv;
+	m->special_gappoh = config.special_gappoh;
+	m->special_gappov = config.special_gappov;
 	m->isoverview = 0;
 	m->sel = NULL;
 	m->is_in_hotarea = 0;
@@ -610,7 +643,7 @@ void createmon(struct wl_listener *listener, void *data) {
 
 	// 初始化 Pertag 等
 	m->pertag = calloc(1, sizeof(Pertag));
-	for (int i = 0; i < config.tag_num + 1; i++)
+	for (int i = 0; i < PERTAG_SLOTS; i++)
 		m->pertag->scroller_state[i] = NULL;
 
 	if (chvt_backup_tag &&
@@ -639,6 +672,11 @@ void createmon(struct wl_listener *listener, void *data) {
 		wlr_scene_node_reparent(&m->blur->node, layers[LyrBlur]);
 		wlr_scene_optimized_blur_set_size(m->blur, m->m.width, m->m.height);
 	}
+
+	m->special_dim_rect =
+		wlr_scene_rect_create(layers[LyrSpecialDim], m->m.width, m->m.height,
+							  (float[4]){0.0f, 0.0f, 0.0f, config.special_dim});
+	special_update_dim(m);
 
 	// ext workspace group
 	m->ext_group = wlr_ext_workspace_group_handle_v1_create(
@@ -693,6 +731,10 @@ void cleanupmon(struct wl_listener *listener, void *data) {
 	if (m->blur) {
 		wlr_scene_node_destroy(&m->blur->node);
 		m->blur = NULL;
+	}
+	if (m->special_dim_rect) {
+		wlr_scene_node_destroy(&m->special_dim_rect->node);
+		m->special_dim_rect = NULL;
 	}
 	if (m->skip_frame_timeout) {
 		monitor_stop_skip_frame_timer(m);
@@ -909,6 +951,8 @@ void updatemons(struct wl_listener *listener, void *data) {
 			wlr_scene_node_set_position(&m->blur->node, m->m.x, m->m.y);
 			wlr_scene_optimized_blur_set_size(m->blur, m->m.width, m->m.height);
 		}
+
+		special_update_dim(m);
 
 		if (m->lock_surface) {
 			struct wlr_scene_tree *scene_tree = m->lock_surface->surface->data;
@@ -1222,9 +1266,18 @@ void gpureset(struct wl_listener *listener, void *data) {
 }
 
 void setgaps(int32_t oh, int32_t ov, int32_t ih, int32_t iv) {
-	selmon->gappoh = MANGO_MAX(oh, 0);
-	selmon->gappov = MANGO_MAX(ov, 0);
-	selmon->gappih = MANGO_MAX(ih, 0);
-	selmon->gappiv = MANGO_MAX(iv, 0);
+	if (!selmon)
+		return;
+	if (selmon->pertag && is_special_active(selmon)) {
+		selmon->special_gappoh = MANGO_MAX(oh, 0);
+		selmon->special_gappov = MANGO_MAX(ov, 0);
+		selmon->special_gappih = MANGO_MAX(ih, 0);
+		selmon->special_gappiv = MANGO_MAX(iv, 0);
+	} else {
+		selmon->gappoh = MANGO_MAX(oh, 0);
+		selmon->gappov = MANGO_MAX(ov, 0);
+		selmon->gappih = MANGO_MAX(ih, 0);
+		selmon->gappiv = MANGO_MAX(iv, 0);
+	}
 	arrange(selmon, false, false);
 }

--- a/src/mango.c
+++ b/src/mango.c
@@ -135,11 +135,13 @@
 	 !(A)->isunglobal)
 #define VISIBLEON(C, M)                                                        \
 	((C) && (M) && (C)->mon == (M) && !(C)->is_logic_hide &&                   \
+	 !(C)->isminimized &&                                                      \
 	 (((C)->tags & (M)->tagset[(M)->seltags] || (C)->isglobal ||               \
 	   (C)->isunglobal)))
 
 #define TAGMATCH(C, M)                                                         \
-	((C) && (M) && (C)->mon == (M) && (((C)->tags & (M)->tagset[(M)->seltags])))
+	((C) && (M) && (C)->mon == (M) && !(C)->is_logic_hide &&                   \
+	 !(C)->isminimized && (((C)->tags & (M)->tagset[(M)->seltags])))
 
 #define ISMODEKEYCODE(KEY)                                                     \
 	((KEY) == 133 || (KEY) == 37 || (KEY) == 64 || (KEY) == 50 ||              \
@@ -150,6 +152,7 @@
 #define LISTEN(E, L, H) wl_signal_add((E), ((L)->notify = (H), (L)))
 
 #define TAGMASK (tagmask)
+#define TAG0_MASK (1U << 31)
 uint32_t tagmask = ((1u << 9) - 1); // 默认 9 个 tag
 
 #define ISFULLSCREEN(A)                                                        \
@@ -204,6 +207,12 @@ enum {
 	LyrTile,
 	LyrMaximize,
 	LyrTop,
+	// special workspace layers: above LyrTop; dim at the bottom, then
+	// tiled / maximized / floating+fullscreen
+	LyrSpecialDim,
+	LyrSpecialTile,
+	LyrSpecialMaximize,
+	LyrSpecialTop,
 	LyrFadeOut,
 	LyrOverlay,
 	LyrIMPopup, // text-input layer
@@ -614,6 +623,11 @@ struct Monitor {
 	int32_t gappiv; /* vertical gap between windows */
 	int32_t gappoh; /* horizontal outer gaps */
 	int32_t gappov; /* vertical outer gaps */
+	// special workspace gaps, per monitor
+	int32_t special_gappih;
+	int32_t special_gappiv;
+	int32_t special_gappoh;
+	int32_t special_gappov;
 	Pertag *pertag;
 	uint32_t ovbk_current_tagset;
 	uint32_t ovbk_prev_tagset;
@@ -624,12 +638,14 @@ struct Monitor {
 	int32_t ov_normal_mode; /* 热区进入时使用普通网格布局 */
 	int32_t ov_tab_layout;	/* overcircle 进入时使用居中 tab 布局 */
 	int32_t only_sleep;
+	bool special_empty_view; // user intentionally opened the empty special view
 	uint32_t visible_clients;
 	uint32_t visible_tiling_clients;
 	uint32_t visible_scroll_tiling_clients;
 	uint32_t visible_fake_tiling_clients;
 	uint32_t hide_clients;
 	struct wlr_scene_optimized_blur *blur;
+	struct wlr_scene_rect *special_dim_rect;
 	char last_open_surface[256];
 	struct wlr_ext_workspace_group_handle_v1 *ext_group;
 	bool iscleanuping;
@@ -921,6 +937,12 @@ static void reset_keyboard_layout(void);
 static void client_update_oldmonname_record(Client *c, Monitor *m);
 static void pending_kill_client(Client *c);
 static uint32_t get_tags_first_tag_num(uint32_t source_tags);
+static inline uint32_t get_mon_curtag(const Monitor *m);
+static inline uint32_t get_client_tag_idx(const Client *c);
+static inline bool is_special_active(const Monitor *m);
+static uint32_t client_target_layer(Client *c);
+static void client_sync_layer(Client *c);
+static void special_update_dim(Monitor *m);
 static void set_layer_open_animaiton(LayerSurface *l, struct wlr_box geo);
 static void init_fadeout_layers(LayerSurface *l);
 static void layer_actual_size(LayerSurface *l, int32_t *width, int32_t *height);
@@ -1234,20 +1256,66 @@ static struct {
 } last_cursor;
 
 #include "config/preset.h"
+// slots: 1..tag_num are normal tags, slot 0 is special tag0,
+// tag_num_MAX + 1 is the all-tags view
+#define PERTAG_ALL_TAGS_IDX (tag_num_MAX + 1)
+#define PERTAG_SLOTS (tag_num_MAX + 2)
 struct Pertag {
 	uint32_t curtag, prevtag;
-	int32_t nmasters[LENGTH(tags) + 1];
-	float mfacts[LENGTH(tags) + 1];
-	int32_t no_hide[LENGTH(tags) + 1];
-	int32_t no_render_border[LENGTH(tags) + 1];
-	int32_t open_as_floating[LENGTH(tags) + 1];
-	float scroller_default_proportion[LENGTH(tags) + 1];
-	float scroller_default_proportion_single[LENGTH(tags) + 1];
-	int32_t scroller_ignore_proportion_single[LENGTH(tags) + 1];
-	struct DwindleNode *dwindle_root[LENGTH(tags) + 1];
-	const Layout *ltidxs[LENGTH(tags) + 1];
-	struct TagScrollerState *scroller_state[LENGTH(tags) + 1];
+	int32_t nmasters[PERTAG_SLOTS];
+	float mfacts[PERTAG_SLOTS];
+	int32_t no_hide[PERTAG_SLOTS];
+	int32_t no_render_border[PERTAG_SLOTS];
+	int32_t open_as_floating[PERTAG_SLOTS];
+	float scroller_default_proportion[PERTAG_SLOTS];
+	float scroller_default_proportion_single[PERTAG_SLOTS];
+	int32_t scroller_ignore_proportion_single[PERTAG_SLOTS];
+	struct DwindleNode *dwindle_root[PERTAG_SLOTS];
+	const Layout *ltidxs[PERTAG_SLOTS];
+	struct TagScrollerState *scroller_state[PERTAG_SLOTS];
 };
+
+static inline uint32_t get_mon_curtag(const Monitor *m) {
+	if (!m || !m->pertag)
+		return 0;
+	// special workspace uses slot 0; all-tags view (curtag==0) uses its own
+	// slot
+	if (is_special_active(m))
+		return 0;
+	return m->pertag->curtag ? m->pertag->curtag : PERTAG_ALL_TAGS_IDX;
+}
+static inline uint32_t get_client_tag_idx(const Client *c) {
+	if (!c || (c->tags & TAG0_MASK))
+		return 0;
+	return get_tags_first_tag_num(c->tags);
+}
+static inline bool is_special_active(const Monitor *m) {
+	return m && !m->isoverview && (m->tagset[m->seltags] & TAG0_MASK);
+}
+// true if m still has a live (not minimized/destroyed) special window
+static inline bool special_has_clients(const Monitor *m) {
+	Client *c;
+	if (!m)
+		return false;
+	wl_list_for_each(c, &clients, link) {
+		if (c->mon == m && !c->iskilling && !c->isminimized &&
+			(c->tags & TAG0_MASK)) {
+			return true;
+		}
+	}
+	return false;
+}
+static inline uint32_t get_monitor_active_tagset(const Monitor *m) {
+	if (!m)
+		return 0;
+	if (is_special_active(m) && m->pertag) {
+		uint32_t prev_set = m->tagset[m->seltags ^ 1] & TAGMASK;
+		return prev_set ? prev_set
+						: (m->pertag->prevtag ? (1U << (m->pertag->prevtag - 1))
+											  : 1);
+	}
+	return m->tagset[m->seltags];
+}
 #include "common/log.h"
 #include "config/parse_config.h"
 


### PR DESCRIPTION
## Summary

Adds a special tag overlay workspace (scratchpad) with full tiling support across layouts (Scroller, Master/Stack, Dwindle, Monocle, Center Tile, etc.) Multiple windows assigned to the special tag tile cohesively over the active workspace beneath an interactive dim barrier.

---

## Key Changes

* **Independent Pertag Slot (`0`):** Sized `Pertag` to `tag_num_MAX + 1` and reserved index `0` for the special workspace. Layout, `mfact`, `nmaster`, scroller state, and dwindle trees operate independently from standard tags.
* **Dedicated Scene Layers:** Introduced `LyrSpecialDim`, `LyrSpecialTile`, `LyrSpecialTop`, and `LyrSpecialFullscreen`. Special windows and dim layers render above normal fullscreen windows (`LyrFullscreen`) and below global overlays.
* **Input Barrier:** `LyrSpecialDim` blocks mouse hover and click events in `xytonode()`, preventing clicks through to background windows.
* **Multi-Monitor Handling:** Enforces a single active special overlay across displays via `ensure_single_special_monitor`, migrating special windows to the active monitor (`selmon`).
* **Auto-Dismiss Lifecycle:** Overlay automatically closes when the last special window is dismissed, untagged, or when switching workspaces with `view`.
* **Animations:** Windows slide in/out from the top edge while underlying windows remain static under the dim layer.
* **IPC & Overview Compatibility:** Hides special windows during overview mode and exposes `"is_special": true` in the IPC client JSON payload.

---

## Configuration & Bindings

### Keybindings

```ini
# Toggle overlay visibility
bind = SUPER, s, toggle_special_tag

# Move focused window to/from special workspace
bind = SUPER+SHIFT, s, tag_special_tag

# Silently send active window to special workspace without shifting view
bind = SUPER+CTRL, s, tag_special_silent

```

### Visuals & Gaps

```ini
# Dimming opacity behind overlay (0.0 to 1.0, default: 0.5)
special_dim = 0.5

# Inner and outer gaps
special_gappih = 10
special_gappiv = 10
special_gappoh = 20
special_gappov = 20

```

### Window & Tag Rules

```ini
# Assign applications directly on launch
windowrule = special_tag:1, appid:spotify
windowrule = special_tag:1, appid:discord

# Default layout for special workspace (id: 0)
tagrule = id:0, layout_name:dwindle

```

---

## Testing & Validation

**Layouts:** Verified proper tiling across Master/Stack, Scroller, Dwindle, and Center Tile.
**Input Handling:** Confirmed `LyrSpecialDim` blocks pass-through hover and click interactions.
**Z-Order:** Verified overlay surfaces cleanly over standard fullscreen windows; fullscreen special windows promote to `LyrSpecialFullscreen`.
**Multi-Monitor:** Confirmed migration to `selmon` and auto-close on previous monitors.
**Lifecycle:** Confirmed overlay auto-dismisses when the last window is closed or moved.
**Rules & IPC:** Verified `special_tag:1` rule matches at launch, overview correctly hides windows, and IPC returns valid `is_special` / `is_special_tag` keys.

---

  <img width="2560" height="1440" alt="Screenshot_2026-09-04_11-46-53"
  src="https://github.com/user-attachments/assets/efb730c3-2641-4964-9eac-35d56706f26e" />
  <img width="2560" height="1440" alt="Screenshot_2026-09-04_11-45-50"
  src="https://github.com/user-attachments/assets/8995cc44-f70a-4ab3-9235-c3c7ba2e4c74" />
  <img width="2560" height="1440" alt="Screenshot_2026-09-04_11-45-11"
  src="https://github.com/user-attachments/assets/ea42c1fd-3e47-40b1-afd9-c9d626c81959" />