### PR TITLE
Feat: Added focus-based dimming

### DIFF
--- a/docs/visuals/effects.md
+++ b/docs/visuals/effects.md
@@ -52,7 +52,7 @@ shadowscolor=0x000000ff
 
 ---
 
-## Opacity & Corner Radius
+## Opacity, Dim & Corner Radius
 
 Control the transparency and roundness of your windows.
 
@@ -63,6 +63,8 @@ Control the transparency and roundness of your windows.
 | `no_radius_when_single` | `0` | Disable radius if only one window is visible. |
 | `focused_opacity` | `1.0` | Opacity for the active window (0.0 - 1.0). |
 | `unfocused_opacity` | `1.0` | Opacity for inactive windows (0.0 - 1.0). |
+| `active_dim` | `0.0` | Dims the active window by (0.0 - 1.0). |
+| `inactive_dim` | `0.0` | Dims inactive windows by (0.0 - 1.0). | 
 
 ```ini
 # Window corner radius in pixels

--- a/docs/window-management/rules.md
+++ b/docs/window-management/rules.md
@@ -65,6 +65,8 @@ windowrule=Parameter:Values,Parameter:Values,appid:Values,title:Values
 | `isnoanimation` | integer | `0` / `1` | Not apply animation |
 | `focused_opacity` | integer | `0` / `1` | Window focused opacity |
 | `unfocused_opacity` | integer | `0` / `1` | Window unfocused opacity |
+| `active_dim` | integer | `0` / `1` | Window focused dim |
+| `inactive_dim` | integer | `0` / `1` | Window unfocused dim|
 | `allow_csd` | integer | `0` / `1` | Allow client side decoration |
 
 > **Tip:** For detailed visual effects configuration, see the [Window Effects](/docs/visuals/effects) page for blur, shadows, and opacity settings.

--- a/src/animation/client.h
+++ b/src/animation/client.h
@@ -273,6 +273,8 @@ void buffer_set_effect(Client *c, BufferData data) {
 	if (config.blur && !c->noblur)
 		wlr_scene_blur_set_corner_radii(c->blur, data.corner_location);
 
+	wlr_scene_rect_set_corner_radii(c->dim, data.corner_location);
+
 	/* overview 卡片直接应用圆角 */
 	if (c->ov_card_tree) {
 		overview_card_set_corner_radii(c, data.corner_location);
@@ -491,6 +493,20 @@ void client_draw_shield(Client *c, struct ivec2 clip_box) {
 	wlr_scene_node_set_position(&c->shield->node, shield_x, shield_y);
 	wlr_scene_rect_set_size(c->shield, shield_width, shield_height);
 	wlr_scene_node_set_enabled(&c->shield->node, true);
+}
+
+void client_draw_dim(Client *c) {
+	if (c->dim_animation.current_dim <= 0.0f) {
+		if (c->dim->node.enabled)
+			wlr_scene_node_set_enabled(&c->dim->node, false);
+		return;
+	}
+
+	wlr_scene_node_raise_to_top(&c->dim->node);
+	wlr_scene_node_set_position(&c->dim->node, c->bw, c->bw);
+	wlr_scene_rect_set_size(c->dim, c->animation.current.width - 2 * c->bw,
+							c->animation.current.height - 2 * c->bw);
+	wlr_scene_node_set_enabled(&c->dim->node, true);
 }
 
 void client_draw_blur(Client *c, struct ivec2 clip_box) {
@@ -927,6 +943,7 @@ void client_apply_clip(Client *c, float factor) {
 		client_draw_groupbar(c, offsets);
 		client_draw_blur(c, surface_clip_offset);
 		client_draw_shield(c, surface_clip_offset);
+		client_draw_dim(c);
 
 		overview_layout_card(c);
 		overview_card_set_corner_radii(c, set_client_corner_location(c));
@@ -957,6 +974,7 @@ void client_apply_clip(Client *c, float factor) {
 		client_draw_groupbar(c, offsets);
 		client_draw_blur(c, surface_clip_offset);
 		client_draw_shield(c, surface_clip_offset);
+		client_draw_dim(c);
 
 		if (clip_box.width <= 0 || clip_box.height <= 0) {
 			should_render_client_surface = false;
@@ -1006,6 +1024,7 @@ void client_apply_clip(Client *c, float factor) {
 	client_draw_shadow(c, offsets);
 	client_draw_groupbar(c, offsets);
 	client_draw_shield(c, surface_clip_offset);
+	client_draw_dim(c);
 	client_draw_blur(c, surface_clip_offset);
 	/* 动画时同步 X11 根 surface 的 dest_size / 裁剪（source_box + dest_size）
 	 */
@@ -1446,6 +1465,7 @@ void resize_apply(Client *c, struct wlr_box geo, ResizeOpts opts) {
 
 		struct ivec2 surface_clip_offset = clip_to_hide(c, &clip, offsets);
 		client_draw_shield(c, surface_clip_offset);
+		client_draw_dim(c);
 		client_draw_blur(c, surface_clip_offset);
 
 		if (client_is_x11(c))
@@ -1500,6 +1520,29 @@ bool client_draw_fadeout_frame(Client *c) {
 
 	fadeout_client_animation_next_tick(c);
 	return true;
+}
+
+void client_set_focused_dim_animation(Client *c) {
+	if (!config.animations) {
+		client_set_dim(c, c->active_dim);
+		return;
+	}
+	c->dim_animation.duration = config.animation_duration_focus;
+	c->dim_animation.target_dim = c->active_dim;
+	c->dim_animation.time_started = get_now_in_ms();
+	c->dim_animation.initial_dim = c->dim_animation.current_dim;
+	c->dim_animation.running = true;
+}
+void client_set_unfocused_dim_animation(Client *c) {
+	if (!config.animations) {
+		client_set_dim(c, c->inactive_dim);
+		return;
+	}
+	c->dim_animation.duration = config.animation_duration_focus;
+	c->dim_animation.target_dim = c->inactive_dim;
+	c->dim_animation.time_started = get_now_in_ms();
+	c->dim_animation.initial_dim = c->dim_animation.current_dim;
+	c->dim_animation.running = true;
 }
 
 void client_set_focused_opacity_animation(Client *c) {
@@ -1642,6 +1685,45 @@ bool client_apply_focus_opacity(Client *c) {
 	return false;
 }
 
+bool client_apply_focus_dim(Client *c) {
+	if (c->isfullscreen) {
+		c->dim_animation.running = false;
+		client_set_dim(c, 0);
+	} else if (config.animations && c->dim_animation.running) {
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+
+		int32_t passed_time =
+			timespec_to_ms(&now) - c->dim_animation.time_started;
+		double linear_progress =
+			c->dim_animation.duration
+				? (double)passed_time / (double)c->dim_animation.duration
+				: 1.0;
+		// float eased_progress = find_animation_curve_at(linear_progress,
+		// FOCUS);
+
+		c->dim_animation.current_dim =
+			c->dim_animation.initial_dim +
+			(c->dim_animation.target_dim - c->dim_animation.initial_dim) *
+				linear_progress;
+		client_set_dim(c, c->dim_animation.current_dim);
+
+		if (linear_progress >= 1.0f)
+			c->dim_animation.running = false;
+		else
+			return true;
+	} else if (c == selmon->sel) {
+		c->dim_animation.running = false;
+		c->dim_animation.current_dim = c->active_dim;
+		client_set_dim(c, c->active_dim);
+	} else {
+		c->dim_animation.running = false;
+		c->dim_animation.current_dim = c->inactive_dim;
+		client_set_dim(c, c->inactive_dim);
+	}
+	return false;
+}
+
 bool client_draw_frame(Client *c) {
 
 	bool need_next_tick = false;
@@ -1656,8 +1738,11 @@ bool client_draw_frame(Client *c) {
 		need_next_tick = force_render || need_next_tick;
 	}
 
-	if (!c->need_output_flush)
-		return client_apply_focus_opacity(c) || need_next_tick;
+	if (!c->need_output_flush) {
+		bool need_fade = client_apply_focus_opacity(c);
+		need_fade = client_apply_focus_dim(c) || need_fade;
+		return need_fade || need_next_tick;
+	}
 
 	if (config.animations && c->animation.running) {
 		need_next_tick = true;
@@ -1667,6 +1752,7 @@ bool client_draw_frame(Client *c) {
 	}
 
 	bool need_fade_focus = client_apply_focus_opacity(c);
+	bool need_fade_dim = client_apply_focus_dim(c);
 
-	return need_next_tick || need_fade_focus;
+	return need_next_tick || need_fade_focus || need_fade_dim;
 }

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -110,6 +110,8 @@ typedef struct {
 	int32_t noblur;
 	float focused_opacity;
 	float unfocused_opacity;
+	float active_dim;
+	float inactive_dim;
 	float scroller_proportion_single;
 	uint32_t passmod;
 	xkb_keysym_t keysym;
@@ -324,6 +326,8 @@ typedef struct {
 	uint32_t swipe_min_threshold;
 	float focused_opacity;
 	float unfocused_opacity;
+	float active_dim;
+	float inactive_dim;
 	float *scroller_proportion_preset;
 	int32_t scroller_proportion_preset_count;
 
@@ -1796,6 +1800,10 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 		config->focused_opacity = atof(value);
 	} else if (strcmp(key, "unfocused_opacity") == 0) {
 		config->unfocused_opacity = atof(value);
+	} else if (strcmp(key, "active_dim") == 0) {
+		config->active_dim = atof(value);
+	} else if (strcmp(key, "inactive_dim") == 0) {
+		config->inactive_dim = atof(value);
 	} else if (strcmp(key, "xkb_rules_rules") == 0) {
 		strncpy(config->xkb_rules_rules, value,
 				sizeof(config->xkb_rules_rules) - 1);
@@ -2729,6 +2737,8 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 		// float rule value, relay to a client property
 		rule->focused_opacity = 0;
 		rule->unfocused_opacity = 0;
+		rule->active_dim = 0;
+		rule->inactive_dim = 0;
 		rule->scroller_proportion_single = 0.0f;
 		rule->scroller_proportion = 0;
 
@@ -2810,6 +2820,10 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 					rule->unfocused_opacity = atof(val);
 				} else if (strcmp(key, "focused_opacity") == 0) {
 					rule->focused_opacity = atof(val);
+				} else if (strcmp(key, "active_dim") == 0) {
+					rule->active_dim = atof(val);
+				} else if (strcmp(key, "inactive_dim") == 0) {
+					rule->inactive_dim = atof(val);
 				} else if (strcmp(key, "isoverlay") == 0) {
 					rule->isoverlay = atoi(val);
 				} else if (strcmp(key, "shield_when_capture") == 0) {
@@ -4444,6 +4458,8 @@ void override_config(void) {
 	config.focused_opacity = CLAMP_FLOAT(config.focused_opacity, 0.0f, 1.0f);
 	config.unfocused_opacity =
 		CLAMP_FLOAT(config.unfocused_opacity, 0.0f, 1.0f);
+	config.active_dim = CLAMP_FLOAT(config.active_dim, 0.0f, 1.0f);
+	config.inactive_dim = CLAMP_FLOAT(config.inactive_dim, 0.0f, 1.0f);
 
 	config.groupbardata.border_width =
 		CLAMP_INT(config.groupbardata.border_width, 0, 100);
@@ -4617,6 +4633,8 @@ void set_value_default() {
 	config.shadows_position_y = 0;
 	config.focused_opacity = 1.0f;
 	config.unfocused_opacity = 1.0f;
+	config.active_dim = 0.0f;
+	config.inactive_dim = 0.0f;
 
 	config.shadowscolor[0] = 0.0f;
 	config.shadowscolor[1] = 0.0f;

--- a/src/manage/client.h
+++ b/src/manage/client.h
@@ -1173,6 +1173,8 @@ static void apply_rule_properties(Client *c, const ConfigWinRule *r) {
 	APPLY_FLOAT_PROP(c, r, scroller_proportion_single);
 	APPLY_FLOAT_PROP(c, r, focused_opacity);
 	APPLY_FLOAT_PROP(c, r, unfocused_opacity);
+	APPLY_FLOAT_PROP(c, r, active_dim);
+	APPLY_FLOAT_PROP(c, r, inactive_dim);
 
 	APPLY_STRING_PROP(c, r, animation_type_open);
 	APPLY_STRING_PROP(c, r, animation_type_close);
@@ -1729,6 +1731,8 @@ void init_client_properties(Client *c) {
 	c->fake_no_border = false;
 	c->focused_opacity = config.focused_opacity;
 	c->unfocused_opacity = config.unfocused_opacity;
+	c->active_dim = config.active_dim;
+	c->inactive_dim = config.inactive_dim;
 	c->nofocus = 0;
 	c->nofadein = 0;
 	c->nofadeout = 0;
@@ -1776,6 +1780,10 @@ void init_client_properties(Client *c) {
 		   sizeof(c->opacity_animation.current_border_color));
 	c->opacity_animation.initial_opacity = c->unfocused_opacity;
 	c->opacity_animation.current_opacity = c->unfocused_opacity;
+	c->dim_animation.initial_dim = c->inactive_dim;
+	c->dim_animation.current_dim = c->inactive_dim;
+	c->dim_animation.target_dim = c->inactive_dim;
+	c->dim_animation.running = false;
 	c->animation.tagining = false;
 	c->animation.running = false;
 	c->animation.overining = false;
@@ -1899,6 +1907,11 @@ mapnotify(struct wl_listener *listener, void *data) {
 	c->shield->node.data = c;
 	wlr_scene_node_lower_to_bottom(&c->shield->node);
 	wlr_scene_node_set_enabled(&c->shield->node, false);
+
+	c->dim = wlr_scene_rect_create(c->scene, 0, 0, (float[4]){0, 0, 0, 0});
+	c->dim->node.data = c;
+	wlr_scene_node_lower_to_bottom(&c->dim->node);
+	wlr_scene_node_set_enabled(&c->dim->node, false);
 
 	if (config.new_is_master && selmon && !is_scroller_layout(selmon))
 		// tile at the top
@@ -2342,6 +2355,12 @@ void client_set_opacity(Client *c, double opacity) {
 								   scene_buffer_apply_opacity, &opacity);
 }
 
+void client_set_dim(Client *c, float dim) {
+	dim = CLAMP_FLOAT(dim, 0.0f, 1.0f);
+	wlr_scene_rect_set_color(c->dim, (float[4]){0, 0, 0, dim});
+	wlr_scene_node_set_enabled(&c->dim->node, dim > 0.0f);
+}
+
 void focusclient(Client *c, int32_t lift) {
 
 	Client *last_focus_client = NULL;
@@ -2395,9 +2414,11 @@ void focusclient(Client *c, int32_t lift) {
 			last_focus_client != c) {
 			last_focus_client->isfocusing = false;
 			client_set_unfocused_opacity_animation(last_focus_client);
+			client_set_unfocused_dim_animation(last_focus_client);
 		}
 
 		client_set_focused_opacity_animation(c);
+		client_set_focused_dim_animation(c);
 
 		// decide whether need to re-arrange
 
@@ -2423,6 +2444,7 @@ void focusclient(Client *c, int32_t lift) {
 
 			um->sel->isfocusing = false;
 			client_set_unfocused_opacity_animation(um->sel);
+			client_set_unfocused_dim_animation(um->sel);
 
 			if (um->sel->foreign_toplevel) {
 				wlr_foreign_toplevel_handle_v1_set_activated(

--- a/src/mango.c
+++ b/src/mango.c
@@ -330,6 +330,15 @@ struct mango_opacity_animation {
 	float initial_border_color[4];
 };
 
+struct mango_dim_animation {
+	bool running;
+	float current_dim;
+	float target_dim;
+	float initial_dim;
+	uint32_t time_started;
+	uint32_t duration;
+};
+
 typedef struct {
 	float width_scale;
 	float height_scale;
@@ -366,6 +375,7 @@ struct Client {
 	struct wlr_scene_rect *splitindicator[4];
 	struct wlr_scene_shadow *shadow;
 	struct wlr_scene_rect *shield;
+	struct wlr_scene_rect *dim;
 	struct wlr_scene_blur *blur;
 	struct wlr_scene_tree *scene_surface;
 	struct wlr_scene_tree *image_capture_tree;
@@ -464,6 +474,7 @@ struct Client {
 	bool need_output_flush;
 	struct mango_animation animation;
 	struct mango_opacity_animation opacity_animation;
+	struct mango_dim_animation dim_animation;
 	int32_t isterm, noswallow;
 	int32_t allow_csd;
 	int32_t force_fakemaximize;
@@ -481,6 +492,8 @@ struct Client {
 	int32_t isunglobal;
 	float focused_opacity;
 	float unfocused_opacity;
+	float active_dim;
+	float inactive_dim;
 	char oldmonname[128];
 	int32_t noblur;
 	float blur_opacity;
@@ -893,6 +906,7 @@ static void client_commit(Client *c);
 static void layer_commit(LayerSurface *l);
 static void client_draw_border(Client *c, struct ivec2 offsets);
 static void client_set_opacity(Client *c, double opacity);
+static void client_set_dim(Client *c, float dim);
 static void init_baked_points(void);
 static void scene_buffer_apply_opacity(struct wlr_scene_buffer *buffer,
 									   int32_t sx, int32_t sy, void *data);


### PR DESCRIPTION
added options:

active_dim - default setting for amount of dim on the focused window, defaults to 0 
inactive_dim - default setting for amount of dim on the unfocused window, defaults to 0

added matching window rules that work identically.

dimming is handled by drawing a rect over the window that shares the window's size, offset by its border and matching its corner radius, and animates correctly on focus change. 
