### PR TITLE
fix: top layer ordering and multi-monitor summoning for special works…

### DIFF
--- a/src/dispatch/bind.c
+++ b/src/dispatch/bind.c
@@ -1715,7 +1715,42 @@ void toggle_special_tag_mon(Monitor *m) {
 				: (m->pertag->prevtag ? (1 << (m->pertag->prevtag - 1)) : 1);
 		client_switch_view(&(Arg){.ui = target}, true);
 	} else {
-		/* Switch to tag 0 */
+		Monitor *om;
+		Client *c;
+
+		/* Transfer layout tree state from any monitor that had it */
+		wl_list_for_each(om, &server.monitors, link) {
+			if (om != m && om->pertag && m->pertag) {
+				if (om->pertag->dwindle_root[0]) {
+					m->pertag->dwindle_root[0] = om->pertag->dwindle_root[0];
+					om->pertag->dwindle_root[0] = NULL;
+				}
+				if (om->pertag->scroller_state[0]) {
+					m->pertag->scroller_state[0] =
+						om->pertag->scroller_state[0];
+					om->pertag->scroller_state[0] = NULL;
+				}
+				if (is_special_active(om))
+					toggle_special_tag_mon(om);
+			}
+		}
+
+		/* Move all special clients to current monitor in one pass */
+		server.selected_monitor = m;
+		wl_list_for_each(c, &server.clients, link) {
+			if ((c->tags & TAG0_MASK) && c->mon != m) {
+				Monitor *oldmon = c->mon;
+				if (oldmon && oldmon->sel == c)
+					oldmon->sel = NULL;
+				c->mon = m;
+				reset_foreign_tolevel(c, oldmon, m);
+				if (c->isfloating)
+					c->float_geom = c->geom =
+						client_center_geometry(c, m, c->geom, 0, 0);
+			}
+		}
+
+		/* Switch to tag 0 and arrange once */
 		client_switch_view(&(Arg){.ui = TAG0_MASK}, true);
 	}
 }


### PR DESCRIPTION
Follow-up to #1356.

## Summary

Fixes multi-monitor summoning and layout tree preservation for the special workspace (`TAG0` overlay). Per review feedback, layer-ordering modifications have been reverted to preserve the compositor's existing stacking hierarchy and window-covering semantics.

## Problem

* **Per-monitor isolation:** Toggling the special workspace on a secondary monitor opened an empty tag whilst windows remained stuck on the previous monitor.
* **Layout corruption:** Transferring windows individually between monitors broke complex structures (such as `dwindle` binary trees and `scroller` state) and scrambled window ordering.

## Solution

Implements atomic tree migration and batch client updates in `bind.c:1704-1756`:

* **Clean teardown:** Closes the special workspace cleanly if open on another monitor, without triggering intermediate relayouts.
* **Tree migration:** Transfers existing layout trees (`dwindle_root[0]` and `scroller_state[0]`) directly to the newly focused monitor to retain node structure, column layout, and split ratios.
* **Batch reassignment:** Reassigns monitor ownership for all `TAG0_MASK` clients in a single pass, updating foreign toplevel states and recentring floating windows.
* **Synchronised render:** Executes a single `client_switch_view(&(Arg){.ui = TAG0_MASK}, true)` to arrange windows on the new monitor in their original order.

## Verification

* [x] **Multi-monitor summoning:** Special workspace consistently follows focus across monitors.
* [x] **Layout integrity:** Verified that complex `dwindle` splits and `scroller` layouts retain exact hierarchy and proportions across transfers.
* [x] **State retention:** Verified that closing and reopening the overlay on alternating monitors preserves focus and window order.