### PR TITLE
chore: Add clang-tools to the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
             scenefx = inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}.default;
           };
           shellOverride = old: {
-            nativeBuildInputs = old.nativeBuildInputs ++ [ ];
+            nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.clang-tools ];
             buildInputs = old.buildInputs ++ [ ];
           };
         in


### PR DESCRIPTION
Allow to run ./format.sh, fail before the command clang-format is on this package who was missing from the flake