### PR TITLE
fix: include stdbool in headers using bool

### DIFF
--- a/include/mango/animation/tag.h
+++ b/include/mango/animation/tag.h
@@ -2,7 +2,7 @@
 #define __ANIMATION_TAG_H__ 1
 
 #include "mango/common/types.h"
-
+#include <stdbool.h>
 void set_tagin_animation(Monitor *m, Client *c);
 void set_arrange_visible(Monitor *m, Client *c, bool want_animation);
 void set_tagout_animation(Monitor *m, Client *c);

--- a/include/mango/ipc/ipc.h
+++ b/include/mango/ipc/ipc.h
@@ -3,6 +3,7 @@
 
 #include "mango/common/types.h"
 #include <cjson/cJSON.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <wayland-util.h>
 

--- a/include/mango/manage/misc.h
+++ b/include/mango/manage/misc.h
@@ -2,6 +2,7 @@
 #define __MANAGE_MISC_H__ 1
 
 #include "mango/common/types.h"
+#include <stdbool.h>
 #include <sys/types.h>
 
 pid_t get_parent_process(pid_t p);


### PR DESCRIPTION
Add the missing <stdbool.h> includes to headers that use the bool type.

The following headers were updated:

include/mango/animation/tag.h
include/mango/ipc/ipc.h
include/mango/manage/misc.h

This fixes compilation errors where bool was not recognized when these headers were included directly.

Testing
Successfully compiled MangoWC after the changes.
Installation completed successfully.