### PR TITLE
fix(nix): patch scenefx GLES precision for nvidia proprietary drivers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,8 +32,20 @@
         }:
         let
           inherit (pkgs) callPackage;
+          # Temporary workaround for broken borders on NVIDIA proprietary drivers (https://github.com/wlrfx/scenefx/pull/177).
+          # Once upstream merges/releases the fix, delete this override and uncomment the default below:
+          # scenefx = inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}.default;
+          scenefx = inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}.default.overrideAttrs (oldAttrs: {
+            postPatch = (oldAttrs.postPatch or "") + ''
+              substituteInPlace render/egl.c \
+                --replace-fail 'attribs[atti++] = 2;' 'attribs[atti++] = 3;'
+              substituteInPlace render/fx_renderer/shaders.c \
+                --replace-fail 'glShaderSource(shader, 1, &src, NULL);' \
+                  'const char *prefix = (type == GL_FRAGMENT_SHADER) ? "#ifndef GL_FRAGMENT_PRECISION_HIGH\n#define GL_FRAGMENT_PRECISION_HIGH 1\n#endif\n" : ""; const GLchar *sources[] = { prefix, src }; glShaderSource(shader, 2, sources, NULL);'
+            '';
+          });
           mango = callPackage ./nix {
-            scenefx = inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}.default;
+            inherit scenefx;
           };
           shellOverride = old: {
             nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.clang-tools ];


### PR DESCRIPTION
## Summary

Temporarily patches `scenefx` in `flake.nix` to resolve jagged window borders and pixelated rounded corners on NixOS systems running proprietary nvidia drivers

## Problem

On systems using nvidia proprietary drivers, the GLES2 implementation defaults to `mediump` float precision in fragment shaders. This reduced precision introduces floating-point quantisation errors during distance and corner radius calculations, leading to

* Jagged stepped window corners
* Pixelated or distorted rounded corners
* Inconsistent or missing border edges

An upstream fix is pending in [wlrfx/scenefx#177](https://github.com/wlrfx/scenefx/pull/177), but it has not yet been merged or tagged in a release.

## Solution

Applies a temporary `postPatch` override to `inputs.scenefx` within `flake.nix`:

* **`render/egl.c`**: Requests a GLES 3 context (`attribs[atti++] = 3`).
* **`render/fx_renderer/shaders.c`**: Enforces `#define GL_FRAGMENT_PRECISION_HIGH 1` in fragment 

Once the upstream PR is merged and tagged in a release, this override can be reverted back to:

```nix
scenefx = inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}.default;
```