### PR TITLE
fix: accept keycode-only modifiers in parse_mod

### DIFF
--- a/src/config/parse_config.c
+++ b/src/config/parse_config.c
@@ -2751,18 +2751,22 @@ uint32_t parse_mod(const char *mod_str) {
 				case 133:
 				case 134:
 					mod |= WLR_MODIFIER_LOGO;
+					match_success = true;
 					break;
 				case 37:
 				case 105:
 					mod |= WLR_MODIFIER_CTRL;
+					match_success = true;
 					break;
 				case 50:
 				case 62:
 					mod |= WLR_MODIFIER_SHIFT;
+					match_success = true;
 					break;
 				case 64:
 				case 108:
 					mod |= WLR_MODIFIER_ALT;
+					match_success = true;
 					break;
 				default:
 					mango_error(false, WLR_ERROR,


### PR DESCRIPTION
The keys docs show binds that use keycodes as the modifier, like `bind=code:64,code:24,killclient` and `bind=code:64+code:133,code:24,killclient`, but neither of them loads. The config check prints `Unknown modifier: code:64` and the bind is dropped.

In `parse_mod()`, the `code:` branch ORs the right modifier bit into `mod` but never sets `match_success`, so when every token is a keycode the function falls through to the `!match_success` path and returns `UINT32_MAX`. A mixed form like `SUPER+code:50` only works because the named modifier sets the flag. This started with bcee63fa (the config check added in 0.12.0), and since `parse_mod()` is shared it also affects mousebind, axisbind, gesturebind and the global keybinding window rule.

The fix sets `match_success` in the four recognised keycode cases, the same way the named-modifier branch does. An unknown keycode such as `code:24` still ends up as an unknown modifier.

I checked it by compiling `trim_whitespace()` and `parse_mod()` straight out of `parse_config.c` into a small harness with stubbed wlroots constants. Before the change `code:64` and `code:64+code:133` return 4294967295, after it they return ALT and ALT|LOGO. `ALT`, `SUPER+SHIFT`, `NONE`, `SUPER+code:50`, `code:24` and `bogus` give the same result either way. I did not build the full compositor, and the file passes clang-format unchanged.

AI tools used
