### PR TITLE
fix: ignore XDG geometry offsets in dirty checks

### DIFF
--- a/src/manage/client.c
+++ b/src/manage/client.c
@@ -2201,8 +2201,7 @@ void handle_client_commit(struct wl_listener *listener, void *data) {
 	if (!c->dirty) {
 		new_geo = &c->surface.xdg->geometry;
 		c->dirty = new_geo->width != c->geom.width - 2 * c->bw ||
-				   new_geo->height != c->geom.height - 2 * c->bw ||
-				   new_geo->x != 0 || new_geo->y != 0;
+				   new_geo->height != c->geom.height - 2 * c->bw;
 	}
 
 	if (c == server.grab_client || !c->dirty)
@@ -2212,8 +2211,7 @@ void handle_client_commit(struct wl_listener *listener, void *data) {
 
 	new_geo = &c->surface.xdg->geometry;
 	c->dirty = new_geo->width != c->geom.width - 2 * c->bw ||
-			   new_geo->height != c->geom.height - 2 * c->bw ||
-			   new_geo->x != 0 || new_geo->y != 0;
+			   new_geo->height != c->geom.height - 2 * c->bw;
 }
 
 void handle_client_unmap(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
XDG window geometry can have a non-zero origin for client-side decorations. Treating x/y offsets as dirty causes repeated resizes for clients such as Chromium.

Only size mismatches should mark the client dirty.