### PR TITLE
fix: reject truncated configuration directives

### DIFF
--- a/src/config/parse_config.c
+++ b/src/config/parse_config.c
@@ -2380,9 +2380,9 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 		}
 
 	} else if (strncmp(key, "source-optional", 15) == 0) {
-		parse_config_file(config, value, false);
+		return parse_config_file(config, value, false);
 	} else if (strncmp(key, "source", 6) == 0) {
-		parse_config_file(config, value, true);
+		return parse_config_file(config, value, true);
 	} else {
 		mango_error(false, WLR_ERROR,
 					"Unknown keyword: "
@@ -2395,19 +2395,31 @@ bool parse_option(Config *config, char *key, char *value, int line_number) {
 }
 bool parse_config_line(Config *config, const char *line, int line_number) {
 	char processed_line[512];
-	strncpy(processed_line, line, sizeof(processed_line) - 1);
-	processed_line[sizeof(processed_line) - 1] = '\0';
+	size_t line_length = strnlen(line, sizeof(processed_line));
+	if (line_length == sizeof(processed_line)) {
+		mango_error(false, WLR_ERROR, "Configuration line exceeds %zu bytes\n",
+					sizeof(processed_line) - 1);
+		return false;
+	}
+	memcpy(processed_line, line, line_length + 1);
 
 	remove_comment(processed_line);
 
-	char key[256], value[256];
-	if (sscanf(processed_line, "%255[^=]=%255[^\n]", key, value) != 2) {
+	char *key = processed_line;
+	char *value = strchr(processed_line, '=');
+	if (!value || value == key || value[1] == '\0' || value[1] == '\n') {
 		mango_error(false, WLR_ERROR, "Invalid line format: %s", line);
 		return false;
 	}
+	*value++ = '\0';
 
 	trim_whitespace(key);
 	trim_whitespace(value);
+	if (strlen(key) > 255 || strlen(value) > 255) {
+		mango_error(false, WLR_ERROR,
+					"Configuration key or value exceeds 255 bytes\n");
+		return false;
+	}
 
 	return parse_option(config, key, value, line_number);
 }
@@ -3110,10 +3122,26 @@ bool parse_config_file(Config *config, const char *file_path, bool must_exist) {
 	uint32_t line_count = 0;
 	while (fgets(line, sizeof(line), file)) {
 		line_count++;
+		bool line_too_long = false;
+		if (!strchr(line, '\n')) {
+			int ch = fgetc(file);
+			line_too_long = ch != '\n' && ch != EOF;
+			/* Never interpret the remainder of a physical line as a new
+			 * directive, including when skipping a long comment. */
+			while (ch != '\n' && ch != EOF)
+				ch = fgetc(file);
+		}
 		if (line[0] == '#' || line[0] == '\n') {
 			continue;
 		}
-		parse_line_correct = parse_config_line(config, line, line_count);
+		if (line_too_long) {
+			mango_error(false, WLR_ERROR,
+						"Configuration line exceeds %zu bytes\n",
+						sizeof(line) - 1);
+			parse_line_correct = false;
+		} else {
+			parse_line_correct = parse_config_line(config, line, line_count);
+		}
 		if (!parse_line_correct) {
 			parse_correct = false;
 			mango_error(false, WLR_INFO,
@@ -4206,17 +4234,16 @@ bool parse_config(void) {
 	}
 
 	bool parse_correct = true;
-	bool keybindings_conflict = false;
 	set_value_default();
 	parse_correct = parse_config_file(&config, filename, true);
 	set_default_key_bindings(&config);
 	override_config();
 
-	keybindings_conflict = check_key_binding_conflicts(&config);
-	keybindings_conflict |= check_mouse_binding_conflicts(&config);
-	keybindings_conflict |= check_axis_binding_conflicts(&config);
-	keybindings_conflict |= check_switch_binding_conflicts(&config);
-	keybindings_conflict |= check_gesture_binding_conflicts(&config);
+	check_key_binding_conflicts(&config);
+	check_mouse_binding_conflicts(&config);
+	check_axis_binding_conflicts(&config);
+	check_switch_binding_conflicts(&config);
+	check_gesture_binding_conflicts(&config);
 
 	// Frees the file path list.
 	if (file_paths) {
@@ -4228,7 +4255,7 @@ bool parse_config(void) {
 		file_paths_count = 0;
 	}
 
-	return parse_correct || keybindings_conflict;
+	return parse_correct;
 }
 
 void reset_blur_params(void) {


### PR DESCRIPTION
## Problem

`parse_config_line()` reads keys and values using `%255[...]`. Values longer than 255 bytes are silently truncated, so `mango -c config.conf -p` can succeed even though an `exec-once` command will not be executed as written. `parse_config_file()` also treats the remainder of a physical line longer than its `fgets()` buffer as another directive.

Related to #308; follows the bounds checking in #317. This patch **does not remove or increase the existing length limits**. It makes overlong directives fail explicitly instead of accepting truncated input.

## Changes

- Check the complete input before copying it, split at the first `=`, and reject trimmed keys or values longer than 255 bytes before calling `parse_option()`.
- Reject non-comment physical lines longer than 511 bytes and consume their remainder. Keep subsequent physical line numbers correct, including after long comments.
- Propagate parsing failures from `source` and existing `source-optional` files; a missing optional file still succeeds.
- Preserve parsing failure in the presence of binding conflicts. Previously `parse_correct || keybindings_conflict` turned an invalid configuration into a successful check whenever a conflict was also reported. Conflict-only configurations retain their existing warning/success behavior.

## Verification

Built upstream `d309aaf36334bd21703d48eaa554ee014d4a58cc` and the patch with Meson, then exercised the actual CLI (`mango -c FILE -p`, with `-c` before `-p`). Ran the project's `format.sh`.

- 255-byte values, surrounding whitespace, and trailing comments: accepted.
- 256-byte values: upstream silently returns 0; patched binary reports the limit and returns 1.
- 511-byte physical lines, with a newline and at EOF: accepted.
- 512-byte non-comment lines: rejected explicitly.
- Overlong line followed by an invalid directive: no parsing of the discarded tail; the following directive is reported at its actual physical line number.
- Long full-line comments followed by a valid directive: skipped as one physical line.
- Invalid nested `source` / existing `source-optional`: return 1 instead of 0.
- Missing `source-optional`: still returns 0.
- A parsing error together with a binding conflict: returns 1 instead of 0.
- Existing desktop configuration: still passes.

No compositor session was started or installed for these checks. The repository has no existing parser test harness; these were temporary CLI regression checks rather than new test infrastructure.

### Minimal reproduction

```sh
python3 -c 'import sys; print("exec-once=" + "x" * 256)' > /tmp/mango-overlong.conf
./build/mango -c /tmp/mango-overlong.conf -p
```

Before: exit 0, no error. After: exit 1, `Configuration key or value exceeds 255 bytes`, plus the config path and line number.
